### PR TITLE
Guard against empty bundles causing crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,10 @@ const npmWalker = Class => class Walker extends Class {
       const rules = defaultRules.join('\n') + '\n'
       this.packageJsonCache = opt.packageJsonCache || new Map()
       super.onReadIgnoreFile(rootBuiltinRules, rules, _=>_)
-    } else
+    } else {
+      this.bundled = []
       this.packageJsonCache = this.parent.packageJsonCache
+    }
   }
 
   filterEntry (entry, partial) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "npm-packlist",
   "version": "1.1.6",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ansi-regex": {
       "version": "2.1.1",
@@ -19,7 +20,10 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "asn1": {
       "version": "0.2.3",
@@ -61,7 +65,10 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "bind-obj-methods": {
       "version": "1.0.0",
@@ -79,12 +86,19 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "requires": {
+        "balanced-match": "0.4.2",
+        "concat-map": "0.0.1"
+      }
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -102,7 +116,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "clean-yaml-object": {
       "version": "0.1.0",
@@ -120,13 +141,19 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -144,12 +171,23 @@
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
       "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
       "dependencies": {
         "js-yaml": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          }
         }
       }
     },
@@ -157,19 +195,29 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.0.2",
+        "which": "1.2.14"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -183,7 +231,10 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "deeper": {
       "version": "2.1.0",
@@ -208,7 +259,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -244,7 +298,11 @@
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "4.0.2",
+        "signal-exit": "3.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -256,7 +314,12 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs-exists-cached": {
       "version": "1.0.0",
@@ -286,13 +349,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -306,7 +375,15 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -318,19 +395,34 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "is-my-json-valid": "2.16.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -342,18 +434,30 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.0"
+      }
     },
     "ignore-walk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.0.tgz",
-      "integrity": "sha512-tKHrQ70YReq6IFyAs/XAQy91mgLVpLExNh3HrjExr6vqg8FLq/vd27D4eAN0K2PodhLjiQu5Xc2Q+AkW/T7hKQ=="
+      "integrity": "sha512-tKHrQ70YReq6IFyAs/XAQy91mgLVpLExNh3HrjExr6vqg8FLq/vd27D4eAN0K2PodhLjiQu5Xc2Q+AkW/T7hKQ==",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -365,7 +469,13 @@
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -402,13 +512,20 @@
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "js-yaml": {
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
       "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      },
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -448,6 +565,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -473,7 +596,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
       "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "mime-db": {
       "version": "1.27.0",
@@ -485,12 +612,18 @@
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -503,6 +636,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -528,11 +664,45 @@
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-10.3.2.tgz",
       "integrity": "sha1-8n9NkfKp2zbCT1dP9cbv/wIz3kY=",
       "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.0",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.1",
+        "istanbul-lib-coverage": "1.1.0",
+        "istanbul-lib-hook": "1.0.6",
+        "istanbul-lib-instrument": "1.7.1",
+        "istanbul-lib-report": "1.1.0",
+        "istanbul-lib-source-maps": "1.2.0",
+        "istanbul-reports": "1.1.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.3",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.1",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.2.4",
+        "test-exclude": "4.1.0",
+        "yargs": "7.1.0",
+        "yargs-parser": "5.0.0"
+      },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.0",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
         },
         "amdefine": {
           "version": "1.0.1",
@@ -552,7 +722,10 @@
         "append-transform": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
         },
         "archy": {
           "version": "1.0.0",
@@ -562,7 +735,10 @@
         "arr-diff": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.0.3"
+          }
         },
         "arr-flatten": {
           "version": "1.0.3",
@@ -587,37 +763,83 @@
         "babel-code-frame": {
           "version": "6.22.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.1"
+          }
         },
         "babel-generator": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
         },
         "babel-messages": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
         },
         "babel-runtime": {
           "version": "6.23.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
         },
         "babel-template": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "lodash": "4.17.4"
+          }
         },
         "babel-traverse": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "debug": "2.6.6",
+            "globals": "9.17.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
         },
         "babel-types": {
           "version": "6.24.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
         },
         "babylon": {
           "version": "6.17.0",
@@ -632,12 +854,21 @@
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "braces": {
           "version": "1.8.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -647,7 +878,12 @@
         "caching-transform": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
         },
         "camelcase": {
           "version": "1.2.1",
@@ -659,18 +895,34 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
         },
         "chalk": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
@@ -708,12 +960,19 @@
         "cross-spawn": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.0.2",
+            "which": "1.2.14"
+          }
         },
         "debug": {
           "version": "2.6.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.3"
+          }
         },
         "debug-log": {
           "version": "1.0.1",
@@ -728,17 +987,26 @@
         "default-require-extensions": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
         },
         "detect-indent": {
           "version": "4.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
         },
         "error-ex": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -753,17 +1021,26 @@
         "expand-brackets": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
         },
         "expand-range": {
           "version": "1.8.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
         },
         "extglob": {
           "version": "0.3.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
         },
         "filename-regex": {
           "version": "2.0.1",
@@ -773,17 +1050,33 @@
         "fill-range": {
           "version": "2.2.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.6",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
         },
         "find-cache-dir": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
         },
         "find-up": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "for-in": {
           "version": "1.0.2",
@@ -793,12 +1086,19 @@
         "for-own": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
         },
         "foreground-child": {
           "version": "1.5.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -813,17 +1113,32 @@
         "glob": {
           "version": "7.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "glob-base": {
           "version": "0.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
         },
         "globals": {
           "version": "9.17.0",
@@ -839,18 +1154,30 @@
           "version": "4.0.8",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.22"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
@@ -870,7 +1197,11 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -880,7 +1211,10 @@
         "invariant": {
           "version": "2.2.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
         },
         "invert-kv": {
           "version": "1.0.0",
@@ -900,7 +1234,10 @@
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
         },
         "is-dotfile": {
           "version": "1.0.2",
@@ -910,7 +1247,10 @@
         "is-equal-shallow": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
         },
         "is-extendable": {
           "version": "0.1.1",
@@ -925,22 +1265,34 @@
         "is-finite": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-glob": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
         },
         "is-number": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.0"
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
@@ -970,7 +1322,10 @@
         "isobject": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
         },
         "istanbul-lib-coverage": {
           "version": "1.1.0",
@@ -980,34 +1335,65 @@
         "istanbul-lib-hook": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
         },
         "istanbul-lib-instrument": {
           "version": "1.7.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.24.1",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "istanbul-lib-coverage": "1.1.0",
+            "semver": "5.3.0"
+          }
         },
         "istanbul-lib-report": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "debug": "2.6.6",
+            "istanbul-lib-coverage": "1.1.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "source-map": "0.5.6"
+          }
         },
         "istanbul-reports": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.8"
+          }
         },
         "js-tokens": {
           "version": "3.0.1",
@@ -1022,7 +1408,10 @@
         "kind-of": {
           "version": "3.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         },
         "lazy-cache": {
           "version": "1.0.4",
@@ -1033,12 +1422,22 @@
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
         },
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
         },
         "lodash": {
           "version": "4.17.4",
@@ -1053,17 +1452,27 @@
         "loose-envify": {
           "version": "1.3.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.1"
+          }
         },
         "lru-cache": {
           "version": "4.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         },
         "md5-hex": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
         },
         "md5-o-matic": {
           "version": "0.1.1",
@@ -1073,17 +1482,38 @@
         "merge-source-map": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
         },
         "micromatch": {
           "version": "2.3.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.0",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          }
         },
         "minimatch": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1093,7 +1523,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "0.7.3",
@@ -1103,12 +1536,21 @@
         "normalize-package-data": {
           "version": "2.3.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.4.2",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          }
         },
         "normalize-path": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.0.1"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1123,17 +1565,28 @@
         "object.omit": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1143,22 +1596,37 @@
         "os-locale": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
         },
         "parse-glob": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.2",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -1173,7 +1641,12 @@
         "path-type": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
         },
         "pify": {
           "version": "2.3.0",
@@ -1188,12 +1661,18 @@
         "pinkie-promise": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
         },
         "pkg-dir": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
         },
         "preserve": {
           "version": "0.2.0",
@@ -1208,17 +1687,30 @@
         "randomatic": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "kind-of": "3.2.0"
+          }
         },
         "read-pkg": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.8",
+            "path-type": "1.1.0"
+          }
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -1228,7 +1720,11 @@
         "regex-cache": {
           "version": "0.4.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
+          }
         },
         "remove-trailing-separator": {
           "version": "1.0.1",
@@ -1248,7 +1744,10 @@
         "repeating": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
         },
         "require-directory": {
           "version": "2.1.1",
@@ -1269,12 +1768,18 @@
           "version": "0.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.1"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -1305,6 +1810,14 @@
           "version": "1.2.4",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.1",
+            "signal-exit": "2.1.2",
+            "which": "1.2.14"
+          },
           "dependencies": {
             "signal-exit": {
               "version": "2.1.2",
@@ -1316,7 +1829,10 @@
         "spdx-correct": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
@@ -1331,17 +1847,28 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         },
         "supports-color": {
           "version": "2.0.0",
@@ -1351,7 +1878,14 @@
         "test-exclude": {
           "version": "4.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -1368,12 +1902,23 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -1386,12 +1931,19 @@
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
         },
         "which": {
           "version": "1.2.14",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
         },
         "which-module": {
           "version": "1.0.0",
@@ -1412,7 +1964,11 @@
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -1422,7 +1978,12 @@
         "write-file-atomic": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
         },
         "y18n": {
           "version": "3.2.1",
@@ -1438,6 +1999,21 @@
           "version": "7.1.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -1447,7 +2023,12 @@
             "cliui": {
               "version": "3.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              }
             }
           }
         },
@@ -1455,6 +2036,9 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
@@ -1475,7 +2059,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "only-shallow": {
       "version": "1.2.0",
@@ -1523,7 +2110,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -1553,19 +2143,53 @@
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
       "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-shims": "1.0.0",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "1.0.1",
+        "util-deprecate": "1.0.2"
+      }
     },
     "request": {
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.0.1"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -1583,7 +2207,10 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "source-map": {
       "version": "0.5.6",
@@ -1595,7 +2222,10 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1608,6 +2238,17 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
       "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jodid25519": "1.0.2",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1627,7 +2268,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
       "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -1639,7 +2283,10 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "supports-color": {
       "version": "2.0.0",
@@ -1651,19 +2298,64 @@
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/tap/-/tap-10.3.2.tgz",
       "integrity": "sha1-d5gvCDaNixgDo7CrX8MA4YF/Mec=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bind-obj-methods": "1.0.0",
+        "bluebird": "3.5.0",
+        "clean-yaml-object": "0.1.0",
+        "color-support": "1.1.2",
+        "coveralls": "2.13.1",
+        "deeper": "2.1.0",
+        "foreground-child": "1.5.6",
+        "fs-exists-cached": "1.0.0",
+        "function-loop": "1.0.1",
+        "glob": "7.1.2",
+        "isexe": "1.1.2",
+        "js-yaml": "3.8.4",
+        "nyc": "10.3.2",
+        "only-shallow": "1.2.0",
+        "opener": "1.4.3",
+        "os-homedir": "1.0.1",
+        "own-or": "1.0.0",
+        "own-or-env": "1.0.0",
+        "readable-stream": "2.2.9",
+        "signal-exit": "3.0.2",
+        "source-map-support": "0.4.15",
+        "stack-utils": "1.0.1",
+        "tap-mocha-reporter": "3.0.3",
+        "tap-parser": "5.3.3",
+        "tmatch": "3.0.0",
+        "trivial-deferred": "1.0.1",
+        "yapool": "1.0.0"
+      }
     },
     "tap-mocha-reporter": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.3.tgz",
       "integrity": "sha1-5ZF/rT2acJV/m3xzbnk764fX2vE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-support": "1.1.2",
+        "debug": "2.6.8",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "js-yaml": "3.8.4",
+        "readable-stream": "2.2.9",
+        "tap-parser": "5.3.3",
+        "unicode-length": "1.0.3"
+      }
     },
     "tap-parser": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.3.3.tgz",
       "integrity": "sha1-U+yKkPJ11v/0PxaeVqZ5UCp0EYU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "events-to-array": "1.1.2",
+        "js-yaml": "3.8.4",
+        "readable-stream": "2.2.9"
+      }
     },
     "tmatch": {
       "version": "3.0.0",
@@ -1675,7 +2367,10 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trivial-deferred": {
       "version": "1.0.1",
@@ -1700,7 +2395,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1",
+        "strip-ansi": "3.0.1"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1718,13 +2417,19 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      },
       "dependencies": {
         "isexe": {
           "version": "2.0.0",


### PR DESCRIPTION
So this is very much a "fix the proximate cause" type patch without going deeper. It does solve the pack problems `npm` was having, but there may be a better place to put this. Is there a reason to not initialize this property in the constructor?