### PR TITLE
Don't exclude test directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ This uses the following rules:
     1. .npmignore and .gitignore files (their effect is in the package
        already, there's no need to include them in the package)
     2. editor junk like `.*.swp`, `._*` and `.*.orig` files
-    3. A `/test/` or `/tests/` folder at the root
-    4. `.npmrc` files (these may contain private configs)
-    5. The `node_modules/.bin` folder
-    6. Waf and gyp cruft like `/build/config.gypi` and `.lock-wscript`
-    7. Darwin's `.DS_Store` files because wtf are those even
-    8. `npm-debug.log` files at the root of a project
+    3. `.npmrc` files (these may contain private configs)
+    4. The `node_modules/.bin` folder
+    5. Waf and gyp cruft like `/build/config.gypi` and `.lock-wscript`
+    6. Darwin's `.DS_Store` files because wtf are those even
+    7. `npm-debug.log` files at the root of a project
 
     You can explicitly re-include any of these with a `files` list in
     `package.json` or a negated ignore file rule.

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const defaultRules = [
   '.DS_Store',
   '._*',
   '*.orig',
-  '/test{,s}/',
   'package-lock.json'
 ]
 


### PR DESCRIPTION
Adding new exclusions to what goes in published artifacts is breaking for npm and the code this replaces didn't exclude tests by default.

The breakingness is definitely a judgement call. I wouldn't view adding more exclusions for gyp temp files or editor cruft as breaking, for example.