### PR TITLE
Restrict auto include to ignore editor backups

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ const npmWalker = Class => class Walker extends Class {
     const rules = [
       pkg.browser ? '!' + pkg.browser : '',
       pkg.main ? '!' + pkg.main : '',
-      '!@(readme|license|licence|notice|changes|changelog|history){,.*}'
+      '!@(readme|license|licence|notice|changes|changelog|history){,.*[^~$]}'
     ].filter(f => f).join('\n') + '\n'
     super.onReadIgnoreFile(packageNecessaryRules, rules, _=>_)
 

--- a/test/ignores.js
+++ b/test/ignores.js
@@ -25,6 +25,7 @@ const json = {
 const expect = [
   'package.json',
   'elf.js',
+  'readme.md',
   'deps/foo/config/config.gypi'
 ]
 
@@ -48,12 +49,22 @@ t.test('setup', t => {
 
   fs.writeFileSync(
     path.join(pkg, '.npmignore'),
-    '.npmignore\ndummy\npackage.json'
+    '.npmignore\ndummy\npackage.json\nreadme.md\n*~'
   )
 
   fs.writeFileSync(
     path.join(pkg, 'dummy'),
     'foo'
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, 'readme.md'),
+    'Elf package readme included even if ignored'
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, 'readme.md~'),
+    'Editor backup file should not be auto-included'
   )
 
   // empty dir should be ignored


### PR DESCRIPTION
To address NPM issues such as https://github.com/npm/npm/issues/17560