### PR TITLE
Never ignore COPYING files

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ const npmWalker = Class => class Walker extends Class {
     const rules = [
       pkg.browser ? '!' + pkg.browser : '',
       pkg.main ? '!' + pkg.main : '',
-      '!@(readme|license|licence|notice|changes|changelog|history){,.*}'
+      '!@(readme|copying|license|licence|notice|changes|changelog|history){,.*}'
     ].filter(f => f).join('\n') + '\n'
     super.onReadIgnoreFile(packageNecessaryRules, rules, _=>_)
 


### PR DESCRIPTION
GNU's GPL usage guides recommend using this name, so never ignore it as it may include a copy of the GPL. See npm/npm#17510 :tada:

Some questions:

* Do I need to add a test for this? I'm just on the web interface at the moment so I can't quite tell, but it *seems* like the answer is no?
* Should we also not ignore `COPYING.{,L}GPL`? Those names are occasionally used too, I think

Happy to amend later today. Thanks <3
