### PR TITLE
Run defaultRules recursively to avoid publishing .DS_Store, .swp, etc

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,14 +62,14 @@ const npmWalker = Class => class Walker extends Class {
       this.bundledScopes = Array.from(new Set(
         this.bundled.filter(f => /^@/.test(f))
         .map(f => f.split('/')[0])))
-      const rules = defaultRules.join('\n') + '\n'
       this.packageJsonCache = opt.packageJsonCache || new Map()
-      super.onReadIgnoreFile(rootBuiltinRules, rules, _=>_)
     } else {
       this.bundled = []
       this.bundledScopes = []
       this.packageJsonCache = this.parent.packageJsonCache
     }
+    const rules = defaultRules.join('\n') + '\n'
+    super.onReadIgnoreFile(rootBuiltinRules, rules, _=>_)
   }
 
   filterEntry (entry, partial) {


### PR DESCRIPTION
Bug Report: https://npm.community/t/ds-store-files-show-up-after-npm-publish/831/3
Related: https://github.com/sindresorhus/clipboardy/pull/41