### PR TITLE
Follow symlinks in bundled scoped dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,11 @@ const npmWalker = Class => class Walker extends Class {
 
     opt.includeEmpty = false
     opt.path = opt.path || process.cwd()
-    opt.follow = path.basename(opt.path) === 'node_modules'
+    const dirName = path.basename(opt.path)
+    const parentName = path.basename(path.dirname(opt.path))
+    opt.follow =
+      dirName === 'node_modules' ||
+      (parentName === 'node_modules' && /^@/.test(dirName))
     super(opt)
 
     // ignore a bunch of things by default at the root level.

--- a/test/bundled-scoped-symlink.js
+++ b/test/bundled-scoped-symlink.js
@@ -1,0 +1,89 @@
+'use strict'
+const fs = require('fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const t = require('tap')
+
+const pack = require('..')
+
+const pkg = path.join(__dirname, path.basename(__filename, '.js'))
+const deppkg = path.join(__dirname, path.basename(__filename, '.js') + '_history')
+t.teardown(_ => {
+  rimraf.sync(pkg)
+  rimraf.sync(deppkg)
+})
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+
+const json = {
+  'name': 'test-package',
+  'version': '3.1.4',
+  'main': 'elf.js',
+  'bundleDependencies': [
+    '@npmwombat/history'
+  ]
+}
+
+const expect = [
+  'package.json',
+  'elf.js',
+  'node_modules/@npmwombat/history/index.js',
+  'node_modules/@npmwombat/history/package.json'
+]
+
+t.test('setup', t => {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, 'elf.js'),
+    elfJS
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, '.npmrc'),
+    'packaged=false'
+  )
+
+  const historyDir = path.join(pkg, 'node_modules/@npmwombat/history')
+  mkdirp.sync(deppkg)
+  fs.writeFileSync(
+    path.join(deppkg, 'package.json'),
+    JSON.stringify({
+      name: '@npmwombat/history',
+      version: '1.0.0',
+      main: 'index.js'
+    }, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'node_modules/@npmwombat'))
+  fs.writeFileSync(
+    path.join(deppkg, 'index.js'),
+    elfJS
+  )
+
+  fs.symlinkSync(deppkg, historyDir)
+
+  t.end()
+})
+
+t.test('includes bundled dependency', function (t) {
+  const check = (files, t) => {
+    t.same(files, expect)
+    t.end()
+  }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
+})

--- a/test/bundled-scoped.js
+++ b/test/bundled-scoped.js
@@ -1,0 +1,82 @@
+'use strict'
+const fs = require('fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const t = require('tap')
+
+const pack = require('../')
+
+const pkg = path.join(__dirname, path.basename(__filename, '.js'))
+t.teardown(_ => rimraf.sync(pkg))
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+
+const json = {
+  'name': 'test-package',
+  'version': '3.1.4',
+  'main': 'elf.js',
+  'bundleDependencies': [
+    '@npmwombat/history'
+  ]
+}
+
+const expect = [
+  'package.json',
+  'elf.js',
+  'node_modules/@npmwombat/history/index.js',
+  'node_modules/@npmwombat/history/package.json'
+]
+
+t.test('setup', t => {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, 'elf.js'),
+    elfJS
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, '.npmrc'),
+    'packaged=false'
+  )
+
+  const historyDir = path.join(pkg, 'node_modules/@npmwombat/history')
+  mkdirp.sync(historyDir)
+  fs.writeFileSync(
+    path.join(historyDir, 'package.json'),
+    JSON.stringify({
+      name: '@npmwombat/history',
+      version: '1.0.0',
+      main: 'index.js'
+    }, null, 2)
+  )
+
+  fs.writeFileSync(
+    path.join(historyDir, 'index.js'),
+    elfJS
+  )
+
+  t.end()
+})
+
+t.test('includes bundled dependency', function (t) {
+  const check = (files, t) => {
+    t.same(files, expect)
+    t.end()
+  }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
+})

--- a/test/bundled-symlink.js
+++ b/test/bundled-symlink.js
@@ -1,0 +1,89 @@
+'use strict'
+const fs = require('fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const t = require('tap')
+
+const pack = require('../')
+
+const pkg = path.join(__dirname, path.basename(__filename, '.js'))
+const deppkg = path.join(__dirname, path.basename(__filename, '.js') + '_history')
+t.teardown(_ => {
+  rimraf.sync(pkg)
+  rimraf.sync(deppkg)
+})
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+
+const json = {
+  'name': 'test-package',
+  'version': '3.1.4',
+  'main': 'elf.js',
+  'bundleDependencies': [
+    'history'
+  ]
+}
+
+const expect = [
+  'package.json',
+  'elf.js',
+  'node_modules/history/index.js',
+  'node_modules/history/package.json'
+]
+
+t.test('setup', t => {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, 'elf.js'),
+    elfJS
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, '.npmrc'),
+    'packaged=false'
+  )
+
+  const historyDir = path.join(pkg, 'node_modules/history')
+  mkdirp.sync(deppkg)
+  fs.writeFileSync(
+    path.join(deppkg, 'package.json'),
+    JSON.stringify({
+      name: 'history',
+      version: '1.0.0',
+      main: 'index.js'
+    }, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(deppkg, 'index.js'),
+    elfJS
+  )
+
+  fs.symlinkSync(deppkg, historyDir)
+
+  t.end()
+})
+
+t.test('includes bundled dependency', function (t) {
+  const check = (files, t) => {
+    t.same(files, expect)
+    t.end()
+  }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
+})

--- a/test/bundled.js
+++ b/test/bundled.js
@@ -1,0 +1,82 @@
+'use strict'
+const fs = require('fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const t = require('tap')
+
+const pack = require('../')
+
+const pkg = path.join(__dirname, path.basename(__filename, '.js'))
+t.teardown(_ => rimraf.sync(pkg))
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+
+const json = {
+  'name': 'test-package',
+  'version': '3.1.4',
+  'main': 'elf.js',
+  'bundleDependencies': [
+    'history'
+  ]
+}
+
+const expect = [
+  'package.json',
+  'elf.js',
+  'node_modules/history/index.js',
+  'node_modules/history/package.json'
+]
+
+t.test('setup', t => {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, 'elf.js'),
+    elfJS
+  )
+
+  fs.writeFileSync(
+    path.join(pkg, '.npmrc'),
+    'packaged=false'
+  )
+
+  const historyDir = path.join(pkg, 'node_modules/history')
+  mkdirp.sync(historyDir)
+  fs.writeFileSync(
+    path.join(historyDir, 'package.json'),
+    JSON.stringify({
+      name: 'history',
+      version: '1.0.0',
+      main: 'index.js'
+    }, null, 2)
+  )
+
+  fs.writeFileSync(
+    path.join(historyDir, 'index.js'),
+    elfJS
+  )
+
+  t.end()
+})
+
+t.test('includes bundled dependency', function (t) {
+  const check = (files, t) => {
+    t.same(files, expect)
+    t.end()
+  }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
+})


### PR DESCRIPTION
Hi! Looks like it's a known problem that `npm pack` doesn't follow symlinks for bundled scoped dependencies, while it does for non-scoped ones. This should close some of the below, all related:
 
* https://github.com/npm/npm/issues/3310
* https://github.com/npm/npm/issues/8614
* https://github.com/npm/npm/issues/9175
* https://github.com/npm/npm/pull/13438
* https://github.com/npm/npm/issues/17708