### PR TITLE
Fix cacheing package.json by full path

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,8 @@ const npmWalker = Class => class Walker extends Class {
   onReadIgnoreFile (file, data, then) {
     if (file === 'package.json')
       try {
-        this.onPackageJson(file, JSON.parse(data), then)
+        const ig = path.resolve(this.path, file)
+        this.onPackageJson(ig, JSON.parse(data), then)
       } catch (er) {
         // ignore package.json files that are not json
         then()

--- a/test/package-json-empty.js
+++ b/test/package-json-empty.js
@@ -104,20 +104,8 @@ t.test('follows npm package ignoring rules', function (t) {
     t.end()
   }
 
-  // also, let's reuse the caches, why not
-  let packageJsonCache, nodeModulesCache
-  t.test('sync', t => {
-    const ws = new pack.WalkerSync({ path: pkg })
-    packageJsonCache = ws.packageJsonCache
-    nodeModulesCache = ws.nodeModulesCache
-    check(ws.start().result, t)
-  })
-
-  t.test('async', t => pack({
-    path: pkg,
-    packageJsonCache: packageJsonCache,
-    nodeModulesCache: nodeModulesCache
-  }).then(files => check(files, t)))
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
 
   t.end()
 })

--- a/test/package-json.js
+++ b/test/package-json.js
@@ -102,20 +102,8 @@ t.test('follows npm package ignoring rules', function (t) {
     t.end()
   }
 
-  // also, let's reuse the caches, why not
-  let packageJsonCache, nodeModulesCache
-  t.test('sync', t => {
-    const ws = new pack.WalkerSync({ path: pkg })
-    packageJsonCache = ws.packageJsonCache
-    nodeModulesCache = ws.nodeModulesCache
-    check(ws.start().result, t)
-  })
-
-  t.test('async', t => pack({
-    path: pkg,
-    packageJsonCache: packageJsonCache,
-    nodeModulesCache: nodeModulesCache
-  }).then(files => check(files, t)))
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
 
   t.end()
 })


### PR DESCRIPTION
While working on https://github.com/npm/npm-packlist/pull/20 I've discovered one case when package.json contents is cached by base name instead of the full path. This doesn't make sense obviously, because all package.json files have the same name. The fix was simple, but it also uncovered a couple of broken test files that were trying to reuse the cache between individual tests -- not a good idea even if it worked.