### PR TITLE
Add yarn.lock to ignored files

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const defaultRules = [
   '._*',
   '*.orig',
   'package-lock.json',
+  'yarn.lock',
   'archived-packages/**',
 ]
 


### PR DESCRIPTION
This file often exists in repositories and should never be published.

I noticed a lot of my dependencies include this file, which tends to be quite big.

I imagine a lot of people use yarn for package management, and npm for publishing. To support this workflow, I think it’s best for npm to ignore the file by default.