### PR TITLE
Support excluding specific file patterns in nested directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,10 @@ const npmWalker = Class => class Walker extends Class {
 
     if (Array.isArray(pkg.files))
       super.onReadIgnoreFile('package.json', '*\n' + pkg.files.map(
-        f => '!' + f + '\n!' + f.replace(/\/+$/, '') + '/**'
+        // to support excluding specific file patterns, don't append "/**" if f ends in "**/!(pattern)"
+        f => /\*\*\/!\([^/]+\)$/.test(f)
+          ? '!' + f
+          : '!' + f + '\n!' + f.replace(/\/+$/, '') + '/**'
       ).join('\n') + '\n', then)
     else
       then()

--- a/test/package-json-glob.js
+++ b/test/package-json-glob.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const t = require('tap')
+
+const pack = require('../')
+
+const pkg = path.join(__dirname, path.basename(__filename, '.js'))
+t.teardown(_ => rimraf.sync(pkg))
+
+const json = {
+  name: 'test-package',
+  version: '1.6.2',
+  files: [
+    'dist/**/!(*.test.*)'
+  ]
+}
+
+const expect = [
+  'package.json',
+  'dist/index.d.ts',
+  'dist/index.js',
+  'dist/lib/util.d.ts',
+  'dist/lib/util.js'
+]
+
+t.test('setup', t => {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+
+  const srcDir = path.join(pkg, 'src')
+  mkdirp.sync(srcDir)
+  fs.writeFileSync(path.join(srcDir, 'index.ts'), 'export const x = () => console.log("index")')
+  fs.writeFileSync(path.join(srcDir, 'index.test.ts'), 'import { x } from "./index"')
+
+  const srcLibDir = path.join(srcDir, 'lib')
+  mkdirp.sync(srcLibDir)
+  fs.writeFileSync(path.join(srcLibDir, 'util.ts'), 'export const y = () => console.log("util")')
+  fs.writeFileSync(path.join(srcLibDir, 'util.test.ts'), 'import { y } from "./util"')
+
+  const distDir = path.join(pkg, 'dist')
+  mkdirp.sync(distDir)
+  fs.writeFileSync(path.join(distDir, 'index.d.ts'), 'export declare function x(): void')
+  fs.writeFileSync(path.join(distDir, 'index.js'), 'exports.x = function () { console.log("index") }')
+  fs.writeFileSync(path.join(distDir, 'index.test.d.ts'), '')
+  fs.writeFileSync(path.join(distDir, 'index.test.js'), 'var x = require("./index").x')
+
+  const distLibDir = path.join(distDir, 'lib')
+  mkdirp.sync(distLibDir)
+  fs.writeFileSync(path.join(distLibDir, 'util.d.ts'), 'export declare function y(): void')
+  fs.writeFileSync(path.join(distLibDir, 'util.js'), 'exports.y = function () { console.log("util") }')
+  fs.writeFileSync(path.join(distLibDir, 'util.test.d.ts'), '')
+  fs.writeFileSync(path.join(distLibDir, 'util.test.js'), 'var y = require("./util").y')
+
+  t.end()
+})
+
+t.test('follows npm package ignoring rules', t => {
+  const check = (files, t) => {
+    t.same(files, expect)
+    t.end()
+  }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
+})


### PR DESCRIPTION
For a file pattern such as `dist/**/!(*.test.js)`, previously it would add an entry of `!dist/**/!(*.test.js)/**` for the ignore-walker, which results in paths such as `dist/lib/x.test.js` getting included in the pack. The fix is to avoid appending the `/**` if the file ends in `**/!(pattern)`.

<details><summary>The CLI output below on a temporary project shows that the current behaviour does not match the glob spec when it comes to excluding file patterns.</summary>
<p>

```
shingy@shingy-vm:~/source/junk$ find . | grep -v node_modules
.
./dist
./dist/index.js
./dist/index.d.ts
./dist/index.test.d.ts
./dist/lib
./dist/lib/utilities.test.d.ts
./dist/lib/utilities.d.ts
./dist/lib/utilities.test.js
./dist/lib/utilities.js
./dist/index.test.js
./src
./src/index.ts
./src/lib
./src/lib/utilities.ts
./src/lib/utilities.test.ts
./src/index.test.ts
./package.json
./yarn.lock
./tsconfig.json
shingy@shingy-vm:~/source/junk$ grep files package.json && npm pack
  "files": ["dist/**/!(*.test.*)"],
npm notice
npm notice 📦  junk@1.0.0
npm notice === Tarball Contents ===
npm notice 203B package.json
npm notice 0    dist/index.d.ts
npm notice 14B  dist/index.js
npm notice 0    dist/lib/utilities.d.ts
npm notice 14B  dist/lib/utilities.js
npm notice 0    dist/lib/utilities.test.d.ts
npm notice 14B  dist/lib/utilities.test.js
npm notice === Tarball Details ===
npm notice name:          junk
npm notice version:       1.0.0
npm notice filename:      junk-1.0.0.tgz
npm notice package size:  390 B
npm notice unpacked size: 245 B
npm notice shasum:        4d09c3f24bb4c12f9249d932662275a3a03d64f4
npm notice integrity:     sha512-XLn+lIxjY9Wn6[...]Kelvri0OiYskQ==
npm notice total files:   7
npm notice
junk-1.0.0.tgz
shingy@shingy-vm:~/source/junk$ node -p "require('glob').sync(require('./package.json').files[0], { nodir: true })"
[ 'dist/index.d.ts',
  'dist/index.js',
  'dist/lib/utilities.d.ts',
  'dist/lib/utilities.js' ]

```

</p>
</details>

Thanks!