### PR TITLE
Add npm-shrinkwrap.json to the list of files to always include

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ const npmWalker = Class => class Walker extends Class {
       pkg.browser ? '!' + pkg.browser : '',
       pkg.main ? '!' + pkg.main : '',
       '!package.json',
+      '!npm-shrinkwrap.json',
       '!@(readme|copying|license|licence|notice|changes|changelog|history){,.*[^~$]}'
     ]
     if (pkg.bin)


### PR DESCRIPTION
If the file exists, including it in the npm package is probably what the developer intended.

Related: https://github.com/shesek/spark-wallet/commit/5827098ecc301e449e58e6077b0abf4e63aa9635