### PR TITLE
fix: A files list should not exclude bundled dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,12 @@ const npmWalker = Class => class Walker extends Class {
 
     pkg.files.push(...this.mustHaveFilesFromPackage(pkg))
 
+    // when bundling _and_ explicitly filtering files,
+    // the root node_modules should always be allowed
+    if (this.bundled.length) {
+      pkg.files.push('/node_modules')
+    }
+
     const patterns = Array.from(new Set(pkg.files)).reduce((set, pattern) => {
       const excl = pattern.match(/^!+/)
       if (excl)

--- a/tap-snapshots/test-bundled-files.js-TAP.test.js
+++ b/tap-snapshots/test-bundled-files.js-TAP.test.js
@@ -1,0 +1,24 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/bundled-files.js TAP bundles dependencies with explicit files > expect resolving Promise 1`] = `
+Array [
+  "eldar.js",
+  "node_modules/quendi/index.js",
+  "node_modules/quendi/package.json",
+  "package.json",
+]
+`
+
+exports[`test/bundled-files.js TAP bundles dependencies with explicit files > must match snapshot 1`] = `
+Array [
+  "eldar.js",
+  "node_modules/quendi/index.js",
+  "node_modules/quendi/package.json",
+  "package.json",
+]
+`

--- a/test/bundled-files.js
+++ b/test/bundled-files.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const t = require('tap')
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    name: 'test-package',
+    version: '3.1.4',
+    bundleDependencies: [
+      'quendi',
+    ],
+    files: [
+      'eldar.js',
+    ],
+  }),
+  'eldar.js': elfJS,
+  'avari.js': elfJS,
+  node_modules: {
+    quendi: {
+      'package.json': JSON.stringify({
+        name: 'quendi',
+        version: '1.0.0',
+      }),
+      'index.js': elfJS,
+    },
+  }
+})
+
+const packlist = require('../')
+
+t.test('bundles dependencies with explicit files', async t => {
+  t.matchSnapshot(packlist.sync({path: pkg}))
+  await t.resolveMatchSnapshot(packlist({path: pkg}))
+})


### PR DESCRIPTION
# What / Why

This preserves npm v6 behavior when _both_ `files` and `bundleDependencies` are configured in the root manifest. While one _could_ workaround this by adding an explicit `'node_modules'` to the `files` list, there is currently no error to indicate this necessity and it yields a frustrating silent error.

## References

* Fixes #44
