### PR TITLE
fix: Respect root manifest provided in opts.packageJsonCache

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,23 @@ const npmWalker = Class => class Walker extends Class {
       return super.onReaddir(entries)
     }
 
+    // when the cache has been seeded with the root manifest,
+    // we must respect that (it may differ from the filesystem)
+    const ig = path.resolve(this.path, 'package.json')
+
+    if (this.packageJsonCache.has(ig)) {
+      const pkg = this.packageJsonCache.get(ig)
+
+      // fall back to filesystem when seeded manifest is invalid
+      if (Object.prototype.toString.call(pkg) !== '[object Object]') {
+        return this.readPackageJson(entries)
+      }
+
+      // feels wonky, but this ensures package bin is _always_
+      // normalized, as well as guarding against invalid JSON
+      return this.getPackageFiles(entries, JSON.stringify(pkg))
+    }
+
     this.readPackageJson(entries)
   }
 

--- a/tap-snapshots/test-package-json-cache.js-TAP.test.js
+++ b/tap-snapshots/test-package-json-cache.js-TAP.test.js
@@ -1,0 +1,34 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/package-json-cache.js TAP seeded with invalid JSON falls back to filesystem > must match snapshot 1`] = `
+Array [
+  "quendi.js",
+  "package.json",
+]
+`
+
+exports[`test/package-json-cache.js TAP seeded with root manifest > expect resolving Promise 1`] = `
+Array [
+  "elf.js",
+  "package.json",
+]
+`
+
+exports[`test/package-json-cache.js TAP seeded with root manifest > must match snapshot 1`] = `
+Array [
+  "elf.js",
+  "package.json",
+]
+`
+
+exports[`test/package-json-cache.js TAP when empty > must match snapshot 1`] = `
+Array [
+  "quendi.js",
+  "package.json",
+]
+`

--- a/test/package-json-cache.js
+++ b/test/package-json-cache.js
@@ -1,0 +1,46 @@
+const t = require('tap')
+const path = require('path')
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    name: 'test-package',
+    version: '3.1.4',
+    files: [
+      'quendi.js'
+    ]
+  }),
+  'elf.js': elfJS,
+  'quendi.js': elfJS,
+})
+
+const rootManifestPath = path.resolve(pkg, 'package.json')
+
+const packlist = require('../')
+
+t.test('seeded with root manifest', async t => {
+  const packageJsonCache = new Map().set(rootManifestPath, {
+    files: [
+      'elf.js'
+    ]
+  })
+  t.matchSnapshot(packlist.sync({ path: pkg, packageJsonCache }))
+  await t.resolveMatchSnapshot(packlist({ path: pkg, packageJsonCache }))
+})
+
+t.test('seeded with invalid JSON falls back to filesystem', t => {
+  t.matchSnapshot(packlist.sync({
+    path: pkg,
+    packageJsonCache: new Map().set(rootManifestPath, "c'est ne pas une j'son")
+  }))
+  t.done()
+})
+
+t.test('when empty', t => {
+  t.matchSnapshot(packlist.sync({ path: pkg, packageJsonCache: new Map() }))
+  t.done()
+})


### PR DESCRIPTION
# What / Why

I'm writing a CLI tool to bundle up a Next.js app, and I find myself wanting to use the logic behind `npm pack` instead of a bunch of cheesy YAML invocations of `cp -r ${thing} ../archive-target` over and over again (after a local build & slow `npm prune --production`, feeding into `tar`) in my CI runner file. This logic isn't specific to a Next app, it just happens to be the context that drove a long afternoon of hacking.

However, I don't want to burden all of my consumers with a (possibly) ornate, hard-to-grok `files` list that would swiftly become a maintenance nightmare. Rather than mutate the manifest during the build, I'd like to pass a primed `packageJsonCache` with the mutated JSON for the root manifest. I've already done the work of reading the file data and parsing, after all.

## References

* n/a
