### PR TITLE
v1: add dependency on npm-normalize-package-bin@^1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,6 +1320,11 @@
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
       "integrity": "sha1-57qarc75YrthJI+RchzZMrP+a90="
     },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "index.js",
   "dependencies": {
     "ignore-walk": "^3.0.1",
-    "npm-bundled": "^1.0.1"
+    "npm-bundled": "^1.0.1",
+    "npm-normalize-package-bin": "^1.0.1"
   },
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "license": "ISC",


### PR DESCRIPTION
The dependency on `npm-normalize-package-bin` is missing in the v1 branch and in the 1.4.7 release.

See: ec4d56e in v1 branch compared to https://github.com/npm/npm-packlist/commit/196df5ceaa55f63a9a36aaafb98e9e37cce4e423 in master.

Closes #45