### PR TITLE
Avoid ELOOP error when encountering symlinks in node_modules

### DIFF
--- a/tap-snapshots/test-symlink.js-TAP.test.js
+++ b/tap-snapshots/test-symlink.js-TAP.test.js
@@ -7,16 +7,22 @@
 'use strict'
 exports[`test/symlink.js TAP follows npm package ignoring rules async > must match snapshot 1`] = `
 Array [
+  "test/resolver/multirepo/packages/a/README",
   "deps/foo/config/config.gypi",
   "elf.js",
+  "test/resolver/multirepo/packages/b/index.js",
   "package.json",
+  "test/resolver/multirepo/packages/a/node_modules/some_dep/package.json",
 ]
 `
 
 exports[`test/symlink.js TAP follows npm package ignoring rules sync > must match snapshot 1`] = `
 Array [
+  "test/resolver/multirepo/packages/a/README",
   "deps/foo/config/config.gypi",
   "elf.js",
+  "test/resolver/multirepo/packages/b/index.js",
   "package.json",
+  "test/resolver/multirepo/packages/a/node_modules/some_dep/package.json",
 ]
 `

--- a/test/symlink.js
+++ b/test/symlink.js
@@ -14,7 +14,7 @@ const pkg = t.testdir({
   'elf.js': elfJS,
   'link.js': t.fixture('symlink', 'elf.js'),
   '.npmrc': 'packaged=false',
-  '.npmignore': '.npmignore\ndummy\npackage.json\n',
+  '.npmignore': '.npmignore\ndummy\n/package.json\n',
   // empty dir should be ignored
   'this': { dir: { is: { empty: { and: { ignored: {}}}}}},
   dummy: 'foo',
@@ -37,6 +37,27 @@ const pkg = t.testdir({
       'README.md': "please don't include me",
     },
   },
+
+  // ljharb's monorepo test goober that blew up
+  test: { resolver: { multirepo: { packages: {
+    a: {
+      README: 'included',
+      node_modules: {
+        some_dep: {
+          'package.json': JSON.stringify({ version: '1.2.3' }),
+        },
+        '@scope': {
+          b: t.fixture('symlink', '../../../b'),
+        },
+      },
+    },
+    b: {
+      'index.js': 'console.log("woop")',
+      node_modules: {
+        a: t.fixture('symlink', '../../a'),
+      },
+    },
+  }}}},
 })
 
 t.test('follows npm package ignoring rules', function (t) {


### PR DESCRIPTION
This avoids a catastrophic failure where a symlink to a package in a
node_modules *other* than the main project node_modules (ie, in a test
repo or workspace) will cause the link to be followed, on the assumption
that it's a bundled dep or else we wouldn't be looking at it.

However, we only filter out non-bundled deps in the *main* node_modules
folder hierarchy, not in a node_modules folder that appears in some
other place in the project.

H/T @ljharb
