### PR TITLE
fix: Add missing bin/index.js to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "license": "ISC",
   "files": [
+    "bin/index.js",
     "index.js"
   ],
   "devDependencies": {


### PR DESCRIPTION
When attempting to install a package that depends on `npm-packlist` in an offline environment an error is thrown that `bin/index.js` is missing.
This can be simulated with an offline registry such as [Verdaccio](https://verdaccio.org/).

```
npm ERR! path /test-project/node_modules/npm-packlist/bin/index.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/test-project/node_modules/npm-packlist/bin/index.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```

This issue can be simply fixed by including `bin/index.js` in the `files` array in `package.json`.