### PR TITLE
fix: allow for bundledDependencies as well as bundleDependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,13 @@ const npmWalker = Class => class Walker extends Class {
 
   getPackageFiles (entries, pkg) {
     try {
+      // XXX this could be changed to use read-package-json-fast
+      // which handles the normalizing of bins for us, and simplifies
+      // the test for bundleDependencies and bundledDependencies later.
+      // HOWEVER if we do this, we need to be sure that we're careful
+      // about what we write back out since rpj-fast removes some fields
+      // that the user likely wants to keep. it also would add a second
+      // file read that we would want to optimize away.
       pkg = normalizePackageBin(JSON.parse(pkg.toString()))
     } catch (er) {
       // not actually a valid package.json
@@ -202,7 +209,7 @@ const npmWalker = Class => class Walker extends Class {
     // the files list as the effective readdir result, that means it
     // looks like we don't have a node_modules folder at all unless we
     // include it here.
-    if (pkg.bundleDependencies && entries.includes('node_modules'))
+    if ((pkg.bundleDependencies || pkg.bundledDependencies) && entries.includes('node_modules'))
       pkg.files.push('node_modules')
 
     const patterns = Array.from(new Set(pkg.files)).reduce((set, pattern) => {

--- a/tap-snapshots/test-bundled-files.js-TAP.test.js
+++ b/tap-snapshots/test-bundled-files.js-TAP.test.js
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/bundled-files.js TAP includes bundled dependency async > must match snapshot 1`] = `
+exports[`test/bundled-files.js TAP includes bundled dependency using bundleDependencies async > must match snapshot 1`] = `
 Array [
   "elf.js",
   "node_modules/history/index.js",
@@ -14,7 +14,25 @@ Array [
 ]
 `
 
-exports[`test/bundled-files.js TAP includes bundled dependency sync > must match snapshot 1`] = `
+exports[`test/bundled-files.js TAP includes bundled dependency using bundleDependencies sync > must match snapshot 1`] = `
+Array [
+  "elf.js",
+  "node_modules/history/index.js",
+  "node_modules/history/package.json",
+  "package.json",
+]
+`
+
+exports[`test/bundled-files.js TAP includes bundled dependency using bundledDependencies async > must match snapshot 1`] = `
+Array [
+  "elf.js",
+  "node_modules/history/index.js",
+  "node_modules/history/package.json",
+  "package.json",
+]
+`
+
+exports[`test/bundled-files.js TAP includes bundled dependency using bundledDependencies sync > must match snapshot 1`] = `
 Array [
   "elf.js",
   "node_modules/history/index.js",

--- a/tap-snapshots/test-bundled.js-TAP.test.js
+++ b/tap-snapshots/test-bundled.js-TAP.test.js
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/bundled.js TAP includes bundled dependency async > must match snapshot 1`] = `
+exports[`test/bundled.js TAP includes bundled dependency using bundleDependencies async > must match snapshot 1`] = `
 Array [
   "elf.js",
   "node_modules/history/index.js",
@@ -14,7 +14,25 @@ Array [
 ]
 `
 
-exports[`test/bundled.js TAP includes bundled dependency sync > must match snapshot 1`] = `
+exports[`test/bundled.js TAP includes bundled dependency using bundleDependencies sync > must match snapshot 1`] = `
+Array [
+  "elf.js",
+  "node_modules/history/index.js",
+  "node_modules/history/package.json",
+  "package.json",
+]
+`
+
+exports[`test/bundled.js TAP includes bundled dependency using bundledDependencies async > must match snapshot 1`] = `
+Array [
+  "elf.js",
+  "node_modules/history/index.js",
+  "node_modules/history/package.json",
+  "package.json",
+]
+`
+
+exports[`test/bundled.js TAP includes bundled dependency using bundledDependencies sync > must match snapshot 1`] = `
 Array [
   "elf.js",
   "node_modules/history/index.js",

--- a/test/bundled-files.js
+++ b/test/bundled-files.js
@@ -11,31 +11,67 @@ module.exports = elf =>
   console.log("i'm a elf")
 `
 
-const pkg = t.testdir({
-  'package.json': JSON.stringify({
-    'name': 'test-package',
-    'version': '3.1.4',
-    'main': 'elf.js',
-    'bundleDependencies': [
-      'history'
-    ],
-    files: [ 'elf.js' ]
-  }),
-  'elf.js': elfJS,
-  '.npmrc': 'packaged=false',
-  node_modules: {
-    history: {
-      'package.json': JSON.stringify({
-        name: '@npmwombat/history',
-        version: '1.0.0',
-        main: 'index.js'
-      }),
-      'index.js': elfJS,
+t.test('includes bundled dependency using bundleDependencies', function (t) {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      'name': 'test-package',
+      'version': '3.1.4',
+      'main': 'elf.js',
+      'bundleDependencies': [
+        'history'
+      ],
+      files: [ 'elf.js' ]
+    }),
+    'elf.js': elfJS,
+    '.npmrc': 'packaged=false',
+    node_modules: {
+      history: {
+        'package.json': JSON.stringify({
+          name: '@npmwombat/history',
+          version: '1.0.0',
+          main: 'index.js'
+        }),
+        'index.js': elfJS,
+      }
     }
+  })
+
+  const check = (files, t) => {
+    t.matchSnapshot(files)
+    t.end()
   }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
 })
 
-t.test('includes bundled dependency', function (t) {
+t.test('includes bundled dependency using bundledDependencies', function (t) {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      'name': 'test-package',
+      'version': '3.1.4',
+      'main': 'elf.js',
+      'bundledDependencies': [
+        'history'
+      ],
+      files: [ 'elf.js' ]
+    }),
+    'elf.js': elfJS,
+    '.npmrc': 'packaged=false',
+    node_modules: {
+      history: {
+        'package.json': JSON.stringify({
+          name: '@npmwombat/history',
+          version: '1.0.0',
+          main: 'index.js'
+        }),
+        'index.js': elfJS,
+      }
+    }
+  })
+
   const check = (files, t) => {
     t.matchSnapshot(files)
     t.end()

--- a/test/bundled.js
+++ b/test/bundled.js
@@ -11,30 +11,65 @@ module.exports = elf =>
   console.log("i'm a elf")
 `
 
-const pkg = t.testdir({
-  'package.json': JSON.stringify({
-    'name': 'test-package',
-    'version': '3.1.4',
-    'main': 'elf.js',
-    'bundleDependencies': [
-      'history'
-    ]
-  }),
-  'elf.js': elfJS,
-  '.npmrc': 'packaged=false',
-  node_modules: {
-    history: {
-      'package.json': JSON.stringify({
-        name: '@npmwombat/history',
-        version: '1.0.0',
-        main: 'index.js'
-      }),
-      'index.js': elfJS,
+t.test('includes bundled dependency using bundleDependencies', function (t) {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      'name': 'test-package',
+      'version': '3.1.4',
+      'main': 'elf.js',
+      'bundleDependencies': [
+        'history'
+      ]
+    }),
+    'elf.js': elfJS,
+    '.npmrc': 'packaged=false',
+    node_modules: {
+      history: {
+        'package.json': JSON.stringify({
+          name: '@npmwombat/history',
+          version: '1.0.0',
+          main: 'index.js'
+        }),
+        'index.js': elfJS,
+      }
     }
+  })
+
+  const check = (files, t) => {
+    t.matchSnapshot(files)
+    t.end()
   }
+
+  t.test('sync', t => check(pack.sync({ path: pkg }), t))
+  t.test('async', t => pack({ path: pkg }).then(files => check(files, t)))
+
+  t.end()
 })
 
-t.test('includes bundled dependency', function (t) {
+t.test('includes bundled dependency using bundledDependencies', function (t) {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      'name': 'test-package',
+      'version': '3.1.4',
+      'main': 'elf.js',
+      'bundledDependencies': [
+        'history'
+      ]
+    }),
+    'elf.js': elfJS,
+    '.npmrc': 'packaged=false',
+    node_modules: {
+      history: {
+        'package.json': JSON.stringify({
+          name: '@npmwombat/history',
+          version: '1.0.0',
+          main: 'index.js'
+        }),
+        'index.js': elfJS,
+      }
+    }
+  })
+
   const check = (files, t) => {
     t.matchSnapshot(files)
     t.end()


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
we document that `bundleDependencies` and `bundledDependencies` are both usable, yet we were failing to pack bundled deps if they were specified as `bundledDependencies`. this corrects that and adds a regression test.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2907