### PR TITLE
fix: always ignore pnpm-lock.yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ const defaultRules = [
   '*.orig',
   '/package-lock.json',
   '/yarn.lock',
+  '/pnpm-lock.yaml',
   '/archived-packages/**',
 ]
 


### PR DESCRIPTION
The npm and yarn lockfiles are already in the default ignore list. The pnpm lockfiles should be ignored as well.