### PR TITLE
fix: always ignore pnpm-lock.yaml

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,7 @@ const defaultRules = [
   '*.orig',
   '/package-lock.json',
   '/yarn.lock',
+  '/pnpm-lock.yaml',
   '/archived-packages/**',
 ]
 


### PR DESCRIPTION
rebase of #64
