### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ class Walker extends IgnoreWalker {
     // hierarchy (ie, not in test/foo/node_modules/ or something).
     const followRe = /^(?:\/node_modules\/(?:@[^/]+\/[^/]+|[^/]+)\/)*\/node_modules(?:\/@[^/]+)?$/
     const rootPath = opt.parent ? opt.parent.root : opt.path
-    const followTestPath = opt.path.replace(/\\/g, '/').substr(rootPath.length)
+    const followTestPath = opt.path.replace(/\\/g, '/').slice(rootPath.length)
     opt.follow = followRe.test(followTestPath)
 
     super(opt)
@@ -239,7 +239,7 @@ class Walker extends IgnoreWalker {
     const patterns = Array.from(new Set(pkg.files)).reduce((set, pattern) => {
       const excl = pattern.match(/^!+/)
       if (excl) {
-        pattern = pattern.substr(excl[0].length)
+        pattern = pattern.slice(excl[0].length)
       }
       // strip off any / from the start of the pattern.  /foo => foo
       pattern = pattern.replace(/^\/+/, '')
@@ -298,7 +298,7 @@ class Walker extends IgnoreWalker {
 
   filterEntry (entry, partial) {
     // get the partial path from the root of the walk
-    const p = this.path.substr(this.root.length + 1)
+    const p = this.path.slice(this.root.length + 1)
     const { isProject } = this
     const pkg = isProject && pathHasPkg(entry)
       ? pkgFromPath(entry)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.