### PR TITLE
fix: strip leading ./ from files array entries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -242,8 +242,8 @@ class Walker extends IgnoreWalker {
       if (excl) {
         pattern = pattern.slice(excl[0].length)
       }
-      // strip off any / from the start of the pattern.  /foo => foo
-      pattern = pattern.replace(/^\/+/, '')
+      // strip off any / or ./ from the start of the pattern.  /foo => foo, ./foo => foo
+      pattern = pattern.replace(/^\.?\/+/, '')
       // an odd number of ! means a negated pattern.  !!foo ==> foo
       const negate = excl && excl[0].length % 2 === 1
       set.push({ pattern, negate })

--- a/test/package-json-files-with-slashes.js
+++ b/test/package-json-files-with-slashes.js
@@ -13,7 +13,7 @@ const pkg = t.testdir({
       '/lib/one.js',
       '/lib/two.js',
       '/lib/tre.js',
-      '/lib/for.js',
+      './lib/for.js',
     ],
   }),
   lib: {


### PR DESCRIPTION
We currently only strip /, but folks likely will want to use ./ because
that works for exports

Closes https://github.com/npm/cli/issues/4850