### PR TITLE
fix: correctly ignore .gitignore when a .npmignore is present outside of the workspace tree

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,10 +34,13 @@ const glob = require('glob')
 const globify = pattern => pattern.split('\\').join('/')
 
 const readOutOfTreeIgnoreFiles = (root, rel, result = '') => {
-  for (const file of ['.gitignore', '.npmignore']) {
+  for (const file of ['.npmignore', '.gitignore']) {
     try {
       const ignoreContent = fs.readFileSync(path.join(root, file), { encoding: 'utf8' })
       result += ignoreContent + '\n'
+      // break the loop immediately after concatting, this allows us to prioritize the
+      // .npmignore and discard the .gitignore if one exists
+      break
     } catch (err) {
       // we ignore ENOENT errors completely because we don't care if the file doesn't exist
       // but we throw everything else because failing to read a file that does exist is

--- a/test/workspace.js
+++ b/test/workspace.js
@@ -109,3 +109,67 @@ t.test('packing a workspace root does not include children', async (t) => {
     'workspaces/foo/package.json',
   ])
 })
+
+t.test('.gitignore is discarded if .npmignore exists outside of tree', async (t) => {
+  const root = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'workspace-root',
+      version: '1.0.0',
+      main: 'root.js',
+      workspaces: ['./workspaces/foo'],
+    }),
+    'root.js': `console.log('hello')`,
+    '.gitignore': 'dont-ignore-me',
+    '.npmignore': 'only-ignore-me',
+    'dont-ignore-me': 'should not be ignored',
+    'only-ignore-me': 'should be ignored',
+    workspaces: {
+      '.gitignore': 'dont-ignore-me-either',
+      '.npmignore': 'ignore-me-also',
+      'dont-ignore-me': 'should not be ignored',
+      'dont-ignore-me-either': 'should not be ignored',
+      'only-ignore-me': 'should be ignored',
+      'ignore-me-also': 'should be ignored',
+      foo: {
+        'package.json': JSON.stringify({
+          name: 'workspace-child',
+          version: '1.0.0',
+          main: 'child.js',
+        }),
+        'child.js': `console.log('hello')`,
+        'dont-ignore-me': 'should not be ignored',
+        'dont-ignore-me-either': 'should not be ignored',
+        'only-ignore-me': 'should be ignored',
+        'ignore-me-also': 'should also be ignored',
+      },
+    },
+  })
+
+  const workspacePath = path.join(root, 'workspaces', 'foo')
+  // this simulates what it looks like when a user does i.e. npm pack -w ./workspaces/foo
+  const files = await packlist({
+    path: workspacePath,
+    prefix: root,
+    workspaces: [workspacePath],
+  })
+  t.same(files, [
+    'dont-ignore-me',
+    'dont-ignore-me-either',
+    'child.js',
+    'package.json',
+  ])
+
+  // here we leave off workspaces to satisfy coverage
+  const secondFiles = await packlist({
+    path: workspacePath,
+    prefix: root,
+  })
+  t.same(secondFiles, [
+    'dont-ignore-me',
+    'dont-ignore-me-either',
+    'ignore-me-also',
+    'only-ignore-me',
+    'child.js',
+    'package.json',
+  ])
+})


### PR DESCRIPTION
previously we were concatting the .npmignore to the .gitignore and using both, which is incorrect. this ensures if a .npmignore exists we only use those rules.

closes #106
