### PR TITLE
feat: npm-shrinkwrap.json files can now be ignored

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -285,7 +285,6 @@ class PackWalker extends IgnoreWalker {
     const strict = [
       ...strictDefaults,
       '!/package.json',
-      '!/npm-shrinkwrap.json',
       '/.git',
       '/node_modules',
       '/package-lock.json',

--- a/test/can-exclude-shrinkwrap.js
+++ b/test/can-exclude-shrinkwrap.js
@@ -1,4 +1,4 @@
-// cannot exclude npm-shrinkwrap.json in the root
+// can exclude npm-shrinkwrap.json in the root
 'use strict'
 
 const Arborist = require('@npmcli/arborist')
@@ -19,7 +19,6 @@ t.test('package with negated files', async (t) => {
   const files = await packlist(tree)
   t.same(files, [
     '.npmignore',
-    'npm-shrinkwrap.json',
     'package.json',
   ])
 })

--- a/test/package-json.js
+++ b/test/package-json.js
@@ -52,7 +52,6 @@ t.test('follows npm package ignoring rules', async (t) => {
   t.same(files, [
     'deps/foo/config/config.gypi',
     'elf.js',
-    'npm-shrinkwrap.json',
     'package.json',
   ])
 })


### PR DESCRIPTION
BREAKING CHANGE: if npm-shrinkwrap.json is included in your .npmignore,
the shrinkwrap will now be excluded from your packlist.
