### PR TITLE
fix: skip missing optional deps when bundling, closes npm/cli#5924

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -384,6 +384,11 @@ class PackWalker extends IgnoreWalker {
 
       // get a reference to the node we're bundling
       const node = this.tree.edgesOut.get(dep).to
+      // if there's no node, this is most likely an optional dependency that hasn't been
+      // installed. just skip it.
+      if (!node) {
+        continue
+      }
       // we use node.path for the path because we want the location the node was linked to,
       // not where it actually lives on disk
       const path = node.path

--- a/test/bundled-missing-optional.js
+++ b/test/bundled-missing-optional.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('../')
+
+const elfJS = `
+module.exports = elf =>
+  console.log("i'm a elf")
+`
+
+t.test('includes bundled dependency using bundleDependencies', async (t) => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-package',
+      version: '3.1.4',
+      main: 'elf.js',
+      dependencies: {
+        history: '1.0.0',
+      },
+      bundleDependencies: [
+        'history',
+      ],
+    }),
+    'elf.js': elfJS,
+    '.npmrc': 'packaged=false',
+    node_modules: {
+      history: {
+        'package.json': JSON.stringify({
+          name: 'history',
+          version: '1.0.0',
+          main: 'index.js',
+          optionalDependencies: {
+            // defined here, but not installed
+            optionalDep: '^1.0.0',
+          },
+        }),
+        'index.js': elfJS,
+      },
+    },
+  })
+
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  t.same(files, [
+    'elf.js',
+    'node_modules/history/index.js',
+    'node_modules/history/package.json',
+    'package.json',
+  ])
+})


### PR DESCRIPTION
when bundling a dependency that has an optional dependency, we must be tolerant for cases where that optional dependency has not been installed. this fix makes it so we skip such packages instead of throwing a confusing error.
