### PR TITLE
fix: exclude non-root README.md/LICENSE files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ arborist.loadActual().then((tree) => {
 This uses the following rules:
 
 1. If a `package.json` file is found, and it has a `files` list,
-   then ignore everything that isn't in `files`.  Always include the
+   then ignore everything that isn't in `files`.  Always include the root
    readme, license, licence and copying files, if they exist, as well
-   as the package.json file itself.
+   as the package.json file itself. Non-root readme, license, licence and
+   copying files are included by default, but can be excluded using the 
+   `files` list e.g. `"!readme"`.
 2. If there's no `package.json` file (or it has no `files` list), and
    there is a `.npmignore` file, then ignore all the files in the
    `.npmignore` file.

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,8 +53,7 @@ const allLevels = [
 const rootOnly = [
   /^!.*readme/i,
   /^!.*copying/i,
-  /^!.*license/i,
-  /^!.*licence/i,
+  /^!.*licen[sc]e/i,
 ]
 
 const normalizePath = (path) => path.split('\\').join('/')
@@ -367,9 +366,9 @@ class PackWalker extends IgnoreWalker {
     this.injectRules(strictRules, strict, callback)
   }
 
-  // excludes non root files by checking if elements from the files array
-  // in package.json contain an ! and readme/license/licence/copying, and
-  // then removing readme/license/licence accordingly from strict defaults
+  // excludes non root files by checking if elements from the files array in
+  // package.json contain an ! and readme/license/licence/copying, and then
+  // removing readme/license/licence/copying accordingly from strict defaults
   excludeNonRoot (file) {
     // Find the pattern
     const matchingPattern = rootOnly.find(regex => regex.test(file))

--- a/lib/index.js
+++ b/lib/index.js
@@ -304,6 +304,14 @@ class PackWalker extends IgnoreWalker {
           file = file.slice(0, -2)
         }
         const inverse = `!${file}`
+
+        // if package.json's files array contains a ! and readme, we exclude non-root files
+        this.excludeNonRoot(file, inverse, 'readme', '!/readme{,.*[^~$]}')
+
+        // if package.json files array contains ! and either license/licence exclude non-root files
+        this.excludeNonRoot(file, inverse, 'license', '!/license{,.*[^~$]}')
+        this.excludeNonRoot(file, inverse, 'licence', '!/licence{,.*[^~$]}')
+
         try {
           // if an entry in the files array is a specific file, then we need to include it as a
           // strict requirement for this package. if it's a directory or a pattern, it's a default
@@ -350,6 +358,17 @@ class PackWalker extends IgnoreWalker {
 
     // and now we add all of the strict rules to our synthetic file
     this.injectRules(strictRules, strict, callback)
+  }
+
+  // excludes non root files by adding the inverse of elements that contain an ! or
+  // readme/license/licence from the files array in package.json to the defaults array
+  // and then removing readme/license/licence from strict defaults
+  excludeNonRoot (file, inverse, exception, strictDefaultString) {
+    if (file.toLowerCase().includes(exception)) {
+      const removeIndex = strictDefaults.indexOf(strictDefaultString)
+      defaults.push(inverse)
+      strictDefaults.splice(removeIndex, 1)
+    }
   }
 
   // custom method: after we've finished gathering the files for the root package, we call this

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,13 +38,16 @@ const defaults = [
 ]
 
 const strictDefaults = [
-  // these are forcibly included at all levels
+  // these are forcibly excluded
+  '/.git',
+]
+
+const allLevels = [
+  // these are included by default but can be excluded by package.json files array
   '!/readme{,.*[^~$]}',
   '!/copying{,.*[^~$]}',
   '!/license{,.*[^~$]}',
   '!/licence{,.*[^~$]}',
-  // these are forcibly excluded
-  '/.git',
 ]
 
 const normalizePath = (path) => path.split('\\').join('/')
@@ -132,6 +135,7 @@ class PackWalker extends IgnoreWalker {
       // known required files for this directory
       this.injectRules(strictRules, [
         ...strictDefaults,
+        ...allLevels,
         ...this.requiredFiles.map((file) => `!${file}`),
       ])
     }
@@ -284,6 +288,7 @@ class PackWalker extends IgnoreWalker {
     const ignores = []
     const strict = [
       ...strictDefaults,
+      ...allLevels,
       '!/package.json',
       '/.git',
       '/node_modules',
@@ -305,12 +310,7 @@ class PackWalker extends IgnoreWalker {
         }
         const inverse = `!${file}`
 
-        // if package.json's files array contains a ! and readme, we exclude non-root files
-        this.excludeNonRoot(file, inverse, 'readme', '!/readme{,.*[^~$]}')
-
-        // if package.json files array contains ! and either license/licence exclude non-root files
-        this.excludeNonRoot(file, inverse, 'license', '!/license{,.*[^~$]}')
-        this.excludeNonRoot(file, inverse, 'licence', '!/licence{,.*[^~$]}')
+        this.excludeNonRoot(file, ['readme', 'license', 'licence', 'copying'])
 
         try {
           // if an entry in the files array is a specific file, then we need to include it as a
@@ -360,14 +360,14 @@ class PackWalker extends IgnoreWalker {
     this.injectRules(strictRules, strict, callback)
   }
 
-  // excludes non root files by adding the inverse of elements that contain an ! or
-  // readme/license/licence from the files array in package.json to the defaults array
-  // and then removing readme/license/licence from strict defaults
-  excludeNonRoot (file, inverse, exception, strictDefaultString) {
-    if (file.toLowerCase().includes(exception)) {
-      const removeIndex = strictDefaults.indexOf(strictDefaultString)
-      defaults.push(inverse)
-      strictDefaults.splice(removeIndex, 1)
+  // excludes non root files by checking if elements from the files array
+  // in package.json contain an ! or readme/license/licence and then
+  // removing readme/license/licence accordingly from strict defaults
+  excludeNonRoot (file, canExclude) {
+    const exception = canExclude.find(element => file.toLowerCase().includes(element))
+    if (exception && file.includes('!')) {
+      const indexToRemove = allLevels.findIndex(element => element.includes(exception))
+      allLevels.splice(indexToRemove, 1)
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,13 @@ const allLevels = [
   '!/licence{,.*[^~$]}',
 ]
 
+const rootOnly = [
+  'readme',
+  'license',
+  'licence',
+  'copying',
+]
+
 const normalizePath = (path) => path.split('\\').join('/')
 
 const readOutOfTreeIgnoreFiles = (root, rel, result = []) => {
@@ -310,7 +317,7 @@ class PackWalker extends IgnoreWalker {
         }
         const inverse = `!${file}`
 
-        this.excludeNonRoot(file, ['readme', 'license', 'licence', 'copying'])
+        this.excludeNonRoot(file, rootOnly)
 
         try {
           // if an entry in the files array is a specific file, then we need to include it as a

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,10 +51,10 @@ const allLevels = [
 ]
 
 const rootOnly = [
-  'readme',
-  'license',
-  'licence',
-  'copying',
+  /^!.*readme/i,
+  /^!.*copying/i,
+  /^!.*license/i,
+  /^!.*licence/i,
 ]
 
 const normalizePath = (path) => path.split('\\').join('/')
@@ -317,7 +317,7 @@ class PackWalker extends IgnoreWalker {
         }
         const inverse = `!${file}`
 
-        this.excludeNonRoot(file, rootOnly)
+        this.excludeNonRoot(file)
 
         try {
           // if an entry in the files array is a specific file, then we need to include it as a
@@ -368,12 +368,15 @@ class PackWalker extends IgnoreWalker {
   }
 
   // excludes non root files by checking if elements from the files array
-  // in package.json contain an ! or readme/license/licence and then
-  // removing readme/license/licence accordingly from strict defaults
-  excludeNonRoot (file, canExclude) {
-    const exception = canExclude.find(element => file.toLowerCase().includes(element))
-    if (exception && file.includes('!')) {
-      const indexToRemove = allLevels.findIndex(element => element.includes(exception))
+  // in package.json contain an ! and readme/license/licence/copying, and
+  // then removing readme/license/licence accordingly from strict defaults
+  excludeNonRoot (file) {
+    // Find the pattern
+    const matchingPattern = rootOnly.find(regex => regex.test(file))
+
+    if (matchingPattern) {
+      // Find which index matches the pattern and remove it from allLevels
+      const indexToRemove = allLevels.findIndex(element => matchingPattern.test(element))
       allLevels.splice(indexToRemove, 1)
     }
   }

--- a/test/package-json-negate-non-root.js
+++ b/test/package-json-negate-non-root.js
@@ -13,36 +13,42 @@ const pkg = t.testdir({
       '!readme.md',
       '!licence',
       '!license',
+      '!copying',
     ],
 
   }),
   'readme.md': 'one',
   licence: 'two',
   license: 'tre',
+  copying: 'for',
   lib: {
     'readme.md': 'one',
     licence: 'two',
     license: 'tre',
+    copying: 'for',
     a: {
       'readme.md': 'one',
       licence: 'two',
       license: 'tre',
+      copying: 'for',
       b: {
         'readme.md': 'one',
-        licence: 'one',
-        license: 'one',
+        licence: 'two',
+        license: 'tre',
+        copying: 'for',
         c: {
           'readme.md': 'one',
-          licence: 'one',
-          license: 'one',
+          licence: 'two',
+          license: 'tre',
+          copying: 'for',
           'file.txt': 'one',
-          'c.js': 'one',
+          'c.js': 'two',
         },
         'file.txt': 'one',
-        'b.js': 'one',
+        'b.js': 'two',
       },
       'file.txt': 'one',
-      'a.js': 'one',
+      'a.js': 'two',
     },
   } })
 
@@ -51,6 +57,7 @@ t.test('package with negated readme, licence and license files', async (t) => {
   const tree = await arborist.loadActual()
   const files = await packlist(tree)
   t.same(files, [
+    'copying',
     'licence',
     'license',
     'lib/a/a.js',

--- a/test/package-json-negate-non-root.js
+++ b/test/package-json-negate-non-root.js
@@ -1,0 +1,62 @@
+// exclude readme, license, and licnce files if package.json
+// files array includes !readme, !license, or !licence
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('../')
+
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    files: [
+      '**/*.js',
+      '!readme.md',
+      '!licence',
+      '!license',
+    ],
+
+  }),
+  'readme.md': 'one',
+  licence: 'two',
+  license: 'tre',
+  lib: {
+    'readme.md': 'one',
+    licence: 'two',
+    license: 'tre',
+    a: {
+      'readme.md': 'one',
+      licence: 'two',
+      license: 'tre',
+      b: {
+        'readme.md': 'one',
+        licence: 'one',
+        license: 'one',
+        c: {
+          'readme.md': 'one',
+          licence: 'one',
+          license: 'one',
+          'file.txt': 'one',
+          'c.js': 'one',
+        },
+        'file.txt': 'one',
+        'b.js': 'one',
+      },
+      'file.txt': 'one',
+      'a.js': 'one',
+    },
+  } })
+
+t.test('package with negated readme, licence and license files', async (t) => {
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  t.same(files, [
+    'licence',
+    'license',
+    'lib/a/a.js',
+    'lib/a/b/b.js',
+    'lib/a/b/c/c.js',
+    'package.json',
+    'readme.md',
+  ])
+})


### PR DESCRIPTION
<!-- What / Why -->

<!-- Describe the request in detail. What it does and why it's being changed. -->
## Summary
Currently, package publishers are not able to exclude non-root readme and license/licence files when publishing or packing their packages, as they are always strictly included.

This solution allows users to exclude non-root readme and license/licence files by excluding them in the files array inside package.json.

![image](https://github.com/npm/npm-packlist/assets/91709196/66fb9cdc-be1a-4454-9083-efa70cbef5d0)

Added a new function called excludeNonRoot, which removes readme, license, or licence from the strictDefaults array, and adds the inverse of the file to the defaults array. This allows the root files to remain, while non roots are ignored.

Additionally, if users would like to, they can also exclude readme, license, or licence files from specific folders, for example: "!lib/**/README.md"

However, if users do not want to use this behavior, they can simply not include !readme, !license, or !licence and the original behavior will be preserved, meaning that ALL of those files, root or non-root, will be included.

## Tap Test
```npm test```
```All results pass```

## Dummy Project
Installed the npm cli repository, and added our changes to the npm-packlist’s index.js under node_modules.

Installed stylelint repository to have a dummy project for testing.
Make changes to package.json

```alias localnpm="node /workspaces/cli/"```
```localnpm pack --dry```

See which files are included/excluded


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
cli issue - [6341](https://github.com/npm/cli/issues/6341)
