### PR TITLE
update ignore-walk and fix tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -298,6 +298,7 @@ class PackWalker extends IgnoreWalker {
       '!/package.json',
       '/.git',
       '/node_modules',
+      '.npmrc',
       '/package-lock.json',
       '/yarn.lock',
       '/pnpm-lock.yaml',

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "ignore-walk": "^6.0.0"
+    "ignore-walk": "^6.0.4"
   },
   "author": "GitHub Inc.",
   "license": "ISC",

--- a/test/bundled-file-in-workspace.js
+++ b/test/bundled-file-in-workspace.js
@@ -36,7 +36,6 @@ t.test('correctly filters files from workspace subdirectory', async (t) => {
   t.same(files, [
     'index.js',
     'package.json',
-    'docs/readme.md', // readme.md is always included
     'docs/bar.txt',
     'docs/foo.txt',
   ])
@@ -85,7 +84,6 @@ t.test('does not filter based on package.json if subdirectory is not a workspace
   t.same(files, [
     'index.js',
     'package.json',
-    'docs/readme.md', // readme.md is always included
     'docs/bar.txt',
     'docs/baz.txt', // was _not_ filtered
     'docs/foo.txt',

--- a/test/ignore-file-included-by-globstar.js
+++ b/test/ignore-file-included-by-globstar.js
@@ -4,9 +4,45 @@ const Arborist = require('@npmcli/arborist')
 const t = require('tap')
 const packlist = require('../')
 
+t.test('exclude certain files always', async t => {
+  const path = t.testdir({
+    '.npmrc': 'secrets=true',
+    '.git': {
+      HEAD: 'empty',
+    },
+    node_modules: {
+      foo: {
+        'index.js': '',
+      },
+    },
+    subdir: {
+      'other.js': '',
+      '.npmrc': 'sneaky=true',
+    },
+    'index.js': '',
+    'glorp.txt': '',
+    'package.json': JSON.stringify({
+      name: '@npmcli/globstar-test',
+      version: '1.0.0',
+      files: ['*'],
+    }),
+    'package-lock.json': '{}',
+    'yarn.lock': '{}',
+    'pnpm-lock.yaml': '{}',
+  })
+  const arborist = new Arborist({ path })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  t.same(files, [
+    'index.js',
+    'subdir/other.js',
+    'package.json',
+    'glorp.txt',
+  ])
+})
+
 t.test('include a globstar, then exclude one of them', async (t) => {
   const path = t.testdir({
-    'foo.js': '',
     'bar.js': '',
     bar: {
       'bar.js': '',

--- a/test/package-json-nested-readme-include-npmignore.js
+++ b/test/package-json-nested-readme-include-npmignore.js
@@ -1,4 +1,4 @@
-// include readme.* files anywhere in a package
+// readme rules can be overridden by files array
 'use strict'
 
 const Arborist = require('@npmcli/arborist')
@@ -60,8 +60,5 @@ t.test('package with negated files', async (t) => {
     'lib/a/b/b.js',
     'lib/a/b/c/c.js',
     'package.json',
-    'lib/a/b/c/readme.md',
-    'lib/a/b/readme.md',
-    'lib/a/readme.md',
   ])
 })


### PR DESCRIPTION
- deps: ignore-walk@6.0.4
- chore: tests reflect fixed ignore-walk rules
- fix: always exclude .npmrc files