### PR TITLE
fix: preserve slashes in specified files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -307,12 +307,10 @@ class PackWalker extends IgnoreWalker {
     if (files) {
       for (let file of files) {
         // invert the rule because these are things we want to include
-        if (file.startsWith('/')) {
+        if (file.startsWith('./')) {
           file = file.slice(1)
-        } else if (file.startsWith('./')) {
-          file = file.slice(2)
         } else if (file.endsWith('/*')) {
-          file = file.slice(0, -2)
+          file = file.slice(0, -1)
         }
         const inverse = `!${file}`
 
@@ -326,7 +324,7 @@ class PackWalker extends IgnoreWalker {
           // if we have a file and we know that, it's strictly required
           if (stat.isFile()) {
             strict.unshift(inverse)
-            this.requiredFiles.push(file)
+            this.requiredFiles.push(file.startsWith('/') ? file.slice(1) : file)
           } else if (stat.isDirectory()) {
             // otherwise, it's a default ignore, and since we got here we know it's not a pattern
             // so we include the directory contents

--- a/test/package-json-dir-with-slashes.js
+++ b/test/package-json-dir-with-slashes.js
@@ -13,6 +13,7 @@ const pkg = t.testdir({
     files: [
       '/lib',
       './lib2',
+      './lib3/*',
     ],
   }),
   lib: {
@@ -26,6 +27,7 @@ const pkg = t.testdir({
     'fiv.js': 'fiv',
     '.DS_Store': 'a store of ds',
   },
+  lib3: 'not a dir',
 })
 
 t.test('package with slash directories', async (t) => {

--- a/test/package-json-files-with-slashes.js
+++ b/test/package-json-files-with-slashes.js
@@ -11,17 +11,20 @@ const packlist = require('../')
 const pkg = t.testdir({
   'package.json': JSON.stringify({
     files: [
+      './fiv.js',
       '/lib/one.js',
       '/lib/two.js',
       '/lib/tre.js',
       './lib/for.js',
     ],
   }),
+  'fiv.js': 'fiv',
   lib: {
     'one.js': 'one',
     'two.js': 'two',
     'tre.js': 'tre',
     'for.js': 'for',
+    'fiv.js': 'fiv',
     '.npmignore': 'two.js',
     '.DS_Store': 'a store of ds',
   },
@@ -32,6 +35,7 @@ t.test('package with slash files', async (t) => {
   const tree = await arborist.loadActual()
   const files = await packlist(tree)
   t.same(files, [
+    'fiv.js',
     'lib/for.js',
     'lib/one.js',
     'lib/tre.js',


### PR DESCRIPTION
This change ensures files selected at the root level are not also selected in child directories and that files don't match as directories.