### PR TITLE
fix: npm ignore file was not getting picked

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const { Walker: IgnoreWalker } = require('ignore-walk')
 const { lstatSync: lstat, readFileSync: readFile } = require('fs')
-const { basename, dirname, extname, join, relative, resolve, sep } = require('path')
+const { basename, extname, join, relative, resolve, sep } = require('path')
 
 // symbols used to represent synthetic rule sets
 const defaultRules = Symbol('npm-packlist.rules.default')
@@ -58,11 +58,15 @@ const rootOnly = [
 
 const normalizePath = (path) => path.split('\\').join('/')
 
-const readOutOfTreeIgnoreFiles = (root, rel, result = []) => {
+const readOutOfTreeIgnoreFiles = (root, rel, result = [], gitResult = []) => {
   for (const file of ['.npmignore', '.gitignore']) {
     try {
       const ignoreContent = readFile(join(root, file), { encoding: 'utf8' })
-      result.push(ignoreContent)
+      if (file === '.gitignore') {
+        gitResult.push(ignoreContent)
+      } else {
+        result.push(ignoreContent)
+      }
       // break the loop immediately after reading, this allows us to prioritize
       // the .npmignore and discard the .gitignore if one is present
       break
@@ -78,14 +82,14 @@ const readOutOfTreeIgnoreFiles = (root, rel, result = []) => {
   }
 
   if (!rel) {
-    return result
+    return (result.length === 0) ? gitResult : result
   }
 
   const firstRel = rel.split(sep, 1)[0]
   const newRoot = join(root, firstRel)
   const newRel = relative(newRoot, join(root, rel))
 
-  return readOutOfTreeIgnoreFiles(newRoot, newRel, result)
+  return readOutOfTreeIgnoreFiles(newRoot, newRel, result, gitResult)
 }
 
 class PackWalker extends IgnoreWalker {
@@ -123,7 +127,7 @@ class PackWalker extends IgnoreWalker {
         // then we know path is a workspace directory. in order to not drop ignore rules
         // from directories between the workspaces root (prefix) and the workspace itself
         // (path) we need to find and read those now
-        const relpath = relative(options.prefix, dirname(options.path))
+        const relpath = relative(options.prefix, options.path)
         additionalDefaults.push(...readOutOfTreeIgnoreFiles(options.prefix, relpath))
       } else if (path === prefix) {
         // on the other hand, if the path and prefix are the same, then we ignore workspaces

--- a/test/ignores.js
+++ b/test/ignores.js
@@ -111,7 +111,6 @@ t.test('follows gitignore and npmignore rules', async (t) => {
   const arborist = new Arborist({ path: pkg + '/packages/pkg1' })
   const tree = await arborist.loadActual()
   const files = await packlist(tree)
-  console.log(files)
   t.match(files, [
     'package.json',
     'dist/file1.md',

--- a/test/ignores.js
+++ b/test/ignores.js
@@ -73,6 +73,19 @@ readme.md
       },
     },
   },
+  packages: {
+    pkg1: {
+      dist: {
+        'file1.md': 'new file',
+      },
+      '.npmignore': 'test*\n*.gz',
+      'package.json': JSON.stringify({
+        name: 'pkg1',
+        version: '1.0.0',
+        main: 'index.js',
+      }),
+    },
+  },
   node_modules: {
     history: {
       'README.md': "please don't include me",
@@ -89,6 +102,18 @@ t.test('follows npm package ignoring rules', async (t) => {
     'deps/foo/config/config.gypi',
     'elf.js',
     'package.json',
+    'packages/pkg1/dist/file1.md',
     'readme.md',
+  ])
+})
+
+t.test('follows gitignore and npmignore rules', async (t) => {
+  const arborist = new Arborist({ path: pkg + '/packages/pkg1' })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  console.log(files)
+  t.match(files, [
+    'package.json',
+    'dist/file1.md',
   ])
 })


### PR DESCRIPTION
The ignore files present into 3rd level subdirectories a\b\c\npmignore was not getting considered. dirname() was issue there which is removed now.

When its starts scanning into subdirectories we need to do recursive call to cover all npmignore and gitignore files and store it into 2 different results.

since npmignore is preferred over gitignore, it will be returned if its present in workspace.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
