### PR TITLE
feat: add bun.lock to ignorelist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -291,6 +291,7 @@ class PackWalker extends IgnoreWalker {
       '/yarn.lock',
       '/pnpm-lock.yaml',
       '/bun.lockb',
+      '/bun.lock',
     ]
 
     // if we have a files array in our package, we need to pull rules from it

--- a/test/nested-lock-and-core.js
+++ b/test/nested-lock-and-core.js
@@ -21,6 +21,10 @@ const pkg = t.testdir({
     lock: 'file',
     include: false,
   }),
+  'bun.lock': JSON.stringify({
+    lock: 'file',
+    include: false,
+  }),
   lib: {
     core: 'no longer excluded dump file',
     'package-lock.json': JSON.stringify({
@@ -32,6 +36,10 @@ const pkg = t.testdir({
       include: true,
     }),
     'bun.lockb': JSON.stringify({
+      lock: 'file',
+      include: true,
+    }),
+    'bun.lock': JSON.stringify({
       lock: 'file',
       include: true,
     }),
@@ -51,6 +59,7 @@ t.test('follows npm package ignoring rules', async (t) => {
     'package.json',
     'lib/yarn.lock',
     'lib/bun.lockb',
+    'lib/bun.lock',
     'core/include-me.txt',
   ])
 })


### PR DESCRIPTION
Followup to https://github.com/npm/npm-packlist/pull/168

`bun.lock` is becoming the new default as of Bun 1.2, to replace their previous `bun.lockb`. This is technically a breaking change, but might be safe enough to land in v11 which excludes `bun.lockb` already?

- https://x.com/bunjavascript/status/1866879040424120625
- https://x.com/bunjavascript/status/1866879046606622941 and https://x.com/jarredsumner/status/1866882061707121084
