### PR TITLE
feat!: exclude bun.lock from package contents

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,10 +53,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -131,10 +127,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Add Problem Matcher

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -97,10 +93,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Add Problem Matcher

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Set npm authToken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -121,10 +117,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/lib/index.js
+++ b/lib/index.js
@@ -298,6 +298,7 @@ class PackWalker extends IgnoreWalker {
       '/yarn.lock',
       '/pnpm-lock.yaml',
       '/bun.lockb',
+      '/bun.lock',
     ]
 
     // if we have a files array in our package, we need to pull rules from it

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "version": "4.30.0",
-    "publish": true
+    "publish": true,
+    "updateNpm": false
   }
 }

--- a/test/nested-lock-and-core.js
+++ b/test/nested-lock-and-core.js
@@ -21,6 +21,10 @@ const pkg = t.testdir({
     lock: 'file',
     include: false,
   }),
+  'bun.lock': JSON.stringify({
+    lock: 'file',
+    include: false,
+  }),
   lib: {
     core: 'no longer excluded dump file',
     'package-lock.json': JSON.stringify({
@@ -32,6 +36,10 @@ const pkg = t.testdir({
       include: true,
     }),
     'bun.lockb': JSON.stringify({
+      lock: 'file',
+      include: true,
+    }),
+    'bun.lock': JSON.stringify({
       lock: 'file',
       include: true,
     }),
@@ -49,6 +57,7 @@ t.test('follows npm package ignoring rules', async (t) => {
     'lib/core',
     'lib/package-lock.json',
     'package.json',
+    'lib/bun.lock',
     'lib/yarn.lock',
     'lib/bun.lockb',
     'core/include-me.txt',


### PR DESCRIPTION
BREAKING CHANGE: bun.lock is now excluded from package contents by default. If you need to include it, add "bun.lock" to the "files" array in your package.json.

closes https://github.com/npm/statusboard/issues/1077