### PR TITLE
feat!: exclude npm-shrinkwrap.json from package contents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -295,6 +295,7 @@ class PackWalker extends IgnoreWalker {
       '/node_modules',
       '.npmrc',
       '/package-lock.json',
+      '/npm-shrinkwrap.json',
       '/yarn.lock',
       '/pnpm-lock.yaml',
       '/bun.lockb',

--- a/test/package-json-roots-and-nests.js
+++ b/test/package-json-roots-and-nests.js
@@ -44,7 +44,6 @@ const pkg = t.testdir({
   'bin.js': 'bin',
   'main.js': 'main',
   'browser.js': 'browser',
-  'npm-shrinkwrap.json': 'sw',
   inc: {
     'package.json': JSON.stringify({ files: [] }),
     'package-lock.json': 'include me plz',
@@ -66,7 +65,6 @@ t.test('package with negated files', async (t) => {
     'bin.js',
     'browser.js',
     'main.js',
-    'npm-shrinkwrap.json',
     'inc/package-lock.json',
     'node_modules/foo/package-lock.json',
     'inc/package.json',


### PR DESCRIPTION
BREAKING CHANGE: `npm-shrinkwrap.json` is no longer included in published tarballs by default. Publishers who need to ship a locked dependency tree should use `bundleDependencies`; publishers with a legitimate reason to include a file literally named `npm-shrinkwrap.json` can still opt back in with a negated `files` entry.
