### PR TITLE
fix!: use real glob semantics for `package.json` files array

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ arborist.loadActual().then((tree) => {
 This uses the following rules:
 
 1. If a `package.json` file is found, and it has a `files` list,
-   then ignore everything that isn't in `files`.  Always include the root
-   readme, license, licence and copying files, if they exist, as well
-   as the package.json file itself. Non-root readme, license, licence and
-   copying files are included by default, but can be excluded using the 
-   `files` list e.g. `"!readme"`.
+   then ignore everything that isn't matched by `files`.  Always include the
+   root readme, license, licence and copying files, if they exist, as well
+   as the package.json file itself.
 2. If there's no `package.json` file (or it has no `files` list), and
    there is a `.npmignore` file, then ignore all the files in the
    `.npmignore` file.
@@ -45,7 +43,7 @@ This uses the following rules:
    bundled dependency.  If it IS a bundled dependency, and it's a
    symbolic link, then the target of the link is included, not the
    symlink itself.
-4. Unless they're explicitly included (by being in a `files` list, or
+5. Unless they're explicitly included (by being in a `files` list, or
    a `!negated` rule in a relevant `.npmignore` or `.gitignore`),
    always ignore certain common cruft files:
 
@@ -58,26 +56,54 @@ This uses the following rules:
     6. Darwin's `.DS_Store` files because wtf are those even
     7. `npm-debug.log` files at the root of a project
 
-    You can explicitly re-include any of these with a `files` list in
-    `package.json` or a negated ignore file rule.
+    You can explicitly re-include most of these with a negated ignore file rule.
+    A small set of files are always ignored regardless of `files` rules:
+    `.git`, `.npmrc`, and `node_modules`.
 
 Only the `package.json` file in the very root of the project is ever
 inspected for a `files` list.  Below the top level of the root package,
 `package.json` is treated as just another file, and no package-specific
 semantics are applied.
 
-### Interaction between `package.json` and `.npmignore` rules
+### Interpretation of the `files` list
 
-In previous versions of this library, the `files` list in `package.json`
-was used as an initial filter to drive further tree walking. That is no
-longer the case as of version 6.0.0.
+Each entry in the `package.json` `files` list is interpreted as a glob
+pattern, expanded against the package root using node's built-in
+[`fs.globSync`](https://nodejs.org/api/fs.html#fsglobsyncpattern-options).
+Literal paths (`lib`, `src/index.js`) are valid globs and resolve to
+themselves; pattern entries (`dist-*`, `**/*.js`) resolve to every
+matching entry on disk; entries that match nothing are silently dropped.
 
-If you have a `package.json` file with a `files` array within, any top
-level `.npmignore` and `.gitignore` files *will be ignored*.
+When an entry matches a directory, the directory and all of its contents
+are included.  This is a documented convenience: writing
+`"files": ["dist"]` does not require also writing `"dist/**"`.
 
-If a _directory_ is listed in `files`, then any rules in nested `.npmignore` files within that directory will be honored.
+A leading `!` makes the entry a negation, removing matches from the
+result.  Negations are evaluated in order, so a later positive entry
+can re-include something a previous negation excluded.
 
-For example, with this package.json:
+#### Pattern semantics are anchored to the package root
+
+Glob patterns are evaluated as paths relative to the package root, not as
+basename-anywhere matchers.  In particular:
+
+* `"*.js"` matches `.js` files at the package root, not at every depth.
+  Use `"**/*.js"` to match at every depth.
+* `"!readme.md"` removes only the root `readme.md`.  Use
+  `"!**/readme.md"` to remove `readme.md` at every depth.
+
+Negations only exclude paths that exist on disk at packlist time: a `!path`
+entry that matches nothing is silently dropped, same as a positive entry
+that matches nothing.  A typo'd negation has no effect.
+
+#### Interaction with `.npmignore`
+
+If a `package.json` `files` array is present, any **top-level**
+`.npmignore` and `.gitignore` files are ignored: the `files` array is
+the sole source of inclusion at the package root.
+
+`.npmignore` files in subdirectories are still honored within their
+subtree.  For example, with this package.json:
 
 ```json
 {
@@ -85,21 +111,10 @@ For example, with this package.json:
 }
 ```
 
-a `.npmignore` file at `dir/.npmignore` (and any subsequent
-sub-directories) will be honored.  However, a `.npmignore` at the root
-level will be skipped.
-
-Additionally, with this package.json:
-
-```
-{
-  "files": ["dir/subdir"]
-}
-```
-
-a `.npmignore` file at `dir/.npmignore` will be honored, as well as `dir/subdir/.npmignore`.
-
-Any specific file matched by an exact filename in the package.json `files` list will be included, and cannot be excluded, by any `.npmignore` files.
+a `.npmignore` at `dir/.npmignore` (and any nested subdirectory) will
+be applied.  This means a file listed both in `files` and excluded by a
+nested `.npmignore` will be excluded from the tarball; if you need such
+a file to ship, remove the `.npmignore` rule.
 
 ## API
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const { Walker: IgnoreWalker } = require('ignore-walk')
-const { lstatSync: lstat, readFileSync: readFile } = require('fs')
-const { basename, dirname, extname, join, relative, resolve, sep } = require('path')
+const { globSync } = require('glob')
+const { readFileSync: readFile } = require('node:fs')
+const { basename, dirname, extname, join, relative, resolve, sep } = require('node:path')
 const { log } = require('proc-log')
 
 // symbols used to represent synthetic rule sets
@@ -97,7 +98,6 @@ class PackWalker extends IgnoreWalker {
     this.isPackage = options.isPackage
     this.seen = options.seen || new Set()
     this.tree = tree
-    this.requiredFiles = options.requiredFiles || []
 
     const additionalDefaults = []
     if (options.prefix && options.workspaces) {
@@ -125,12 +125,8 @@ class PackWalker extends IgnoreWalker {
     this.injectRules(defaultRules, [...defaults, ...additionalDefaults])
 
     if (!this.isPackage) {
-      // if this instance is not a package, then place some strict default rules, and append
-      // known required files for this directory
-      this.injectRules(strictRules, [
-        ...strictDefaults,
-        ...this.requiredFiles.map((file) => `!${file}`),
-      ])
+      // if this instance is not a package, then place some strict default rules
+      this.injectRules(strictRules, [...strictDefaults])
     }
   }
 
@@ -234,15 +230,6 @@ class PackWalker extends IgnoreWalker {
     return {
       ...super.walkerOpt(entry, opts),
       ignoreFiles,
-      // we map over our own requiredFiles and pass ones that are within this entry
-      requiredFiles: this.requiredFiles
-        .map((file) => {
-          if (relative(file, entry) === '..') {
-            return relative(entry, file).replace(/\\/g, '/')
-          }
-          return false
-        })
-        .filter(Boolean),
     }
   }
 
@@ -304,39 +291,51 @@ class PackWalker extends IgnoreWalker {
 
     // if we have a files array in our package, we need to pull rules from it
     if (files) {
-      for (let file of files) {
-        // invert the rule because these are things we want to include
-        if (file.startsWith('./')) {
-          file = file.slice(1)
+      for (const entry of files) {
+        const isNegation = entry.startsWith('!')
+        // normalize: strip leading `!`s, `./`, a single leading `/`, and trailing slashes.
+        // trailing slashes confuse glob; the leading forms are equivalent to their stripped versions for glob expansion.
+        const pattern = (isNegation ? entry.replace(/^!+/, '') : entry)
+          .replace(/^\.?\//, '')
+          .replace(/\/+$/, '')
+        if (!pattern) {
+          continue
         }
-        if (file.endsWith('/*')) {
-          file += '*'
-        }
-        const inverse = `!${file}`
+
+        // expand the entry as a glob against the package root.
+        // literal paths (e.g. `lib`, `lib/foo.js`) are valid globs and resolve to themselves;
+        // patterns (e.g. `dist-*`, `**/*.js`) resolve to all matching entries;
+        // typos and non-existent entries resolve to nothing.
+        let matches = []
         try {
-          // if an entry in the files array is a specific file, then we need to include it as a
-          // strict requirement for this package. if it's a directory or a pattern, it's a default
-          // pattern instead. this is ugly, but we have to stat to find out if it's a file
-          const stat = lstat(join(this.path, file.replace(/^!+/, '')).replace(/\\/g, '/'))
-          // if we have a file and we know that, it's strictly required
-          if (stat.isFile()) {
-            strict.unshift(inverse)
-            this.requiredFiles.push(file.startsWith('/') ? file.slice(1) : file)
-          } else if (stat.isDirectory()) {
-            // otherwise, it's a default ignore, and since we got here we know it's not a pattern
-            // so we include the directory contents
-            ignores.push(inverse)
-            ignores.push(`${inverse}/**`)
+          matches = globSync(pattern, { cwd: this.path, withFileTypes: true, dot: true })
+        } catch {
+          // unparseable globs produce no matches and drop silently.
+          // (Pre-v11 instead fell through to push the raw entry as an ignore-walk pattern rule; we deliberately don't preserve that.)
+        }
+
+        // a positive entry produces `!path` rules (un-ignore from the surrounding `*` deny-all); a negation produces `path` rules (re-ignore them).
+        // directory matches expand to also include their contents; this is documented `files[]` behavior, not a glob hack.
+        const prefix = isNegation ? '' : '!'
+        for (const match of matches) {
+          const rel = match.relativePosix()
+          // istanbul ignore next -- defensive: glob with withFileTypes returns the cwd as an entry with an empty relative path; skip it.
+          if (!rel) {
+            continue
           }
-          // if the thing exists, but is neither a file or a directory, we don't want it at all
-        } catch (err) {
-          // if lstat throws, then we assume we're looking at a pattern and treat it as a default
-          ignores.push(inverse)
+          if (match.isDirectory()) {
+            ignores.push(`${prefix}/${rel}`)
+            ignores.push(`${prefix}/${rel}/**`)
+            continue
+          }
+          // istanbul ignore else -- non-file-non-dir matches (sockets, fifos, broken symlinks) drop silently.
+          if (match.isFile()) {
+            ignores.push(`${prefix}/${rel}`)
+          }
         }
       }
 
-      // we prepend a '*' to exclude everything, followed by our inverted file rules
-      // which now mean to include those
+      // we prepend a '*' to exclude everything, followed by our inverted file rules which now mean to include those
       this.injectRules('package.json', ['*', ...ignores])
     }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "glob": "^13.0.6",
     "ignore-walk": "^8.0.0",
     "proc-log": "^6.0.0"
   },

--- a/test/bundled-files-glob.js
+++ b/test/bundled-files-glob.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('../')
+
+// Verify that the new files[] glob semantics apply to bundled dependencies as
+// well, not just the project root. processPackage runs for every package root
+// in the walk (including bundled deps), so a bundled dep with `files: ["dist-*"]`
+// should pull in dist-cjs/index.js, dist-es/index.js, and dist-other.js -- the
+// same regression that cli#7514 reports for the top-level package.
+t.test('bundled dep with files: ["dist-*"] expands directory matches', async (t) => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'root',
+      version: '1.0.0',
+      main: 'index.js',
+      dependencies: {
+        bundled: '1.0.0',
+      },
+      bundleDependencies: ['bundled'],
+    }),
+    'index.js': '',
+    node_modules: {
+      bundled: {
+        'package.json': JSON.stringify({
+          name: 'bundled',
+          version: '1.0.0',
+          files: ['dist-*'],
+        }),
+        'dist-cjs': { 'index.js': 'cjs' },
+        'dist-es': { 'index.js': 'es' },
+        'dist-other.js': 'other',
+        'should-not-pack.js': 'nope',
+      },
+    },
+  })
+
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  t.same(files.sort(), [
+    'index.js',
+    'node_modules/bundled/dist-cjs/index.js',
+    'node_modules/bundled/dist-es/index.js',
+    'node_modules/bundled/dist-other.js',
+    'node_modules/bundled/package.json',
+    'package.json',
+  ].sort())
+})

--- a/test/cannot-include-non-file-or-directory.js
+++ b/test/cannot-include-non-file-or-directory.js
@@ -41,16 +41,27 @@ t.test('cannot include something that exists but is neither a file nor a directo
     },
   })
 
+  // mock glob so the Path object for `device` reports as neither file nor
+  // directory; this is the path through which packlist now resolves `files[]`
+  // entries (no separate lstatSync probe), so the test must intercept here.
+  const realGlob = require('glob')
   const packlist = t.mock('../', {
     'ignore-walk': ignoreWalk,
-    fs: {
-      ...fs,
-      lstatSync: (path) => {
-        if (path === join(pkg, 'device').replace(/\\/g, '/')) {
-          return { isFile: () => false, isDirectory: () => false }
-        }
-
-        return fs.lstatSync(path)
+    glob: {
+      ...realGlob,
+      globSync: (pattern, options) => {
+        const real = realGlob.globSync(pattern, options)
+        return real.map((entry) => {
+          if (typeof entry === 'string') {
+            return entry
+          }
+          if (entry.name === 'device') {
+            entry.isFile = () => false
+            entry.isDirectory = () => false
+            entry.isSymbolicLink = () => false
+          }
+          return entry
+        })
       },
     },
   })

--- a/test/package-json-directory-glob.js
+++ b/test/package-json-directory-glob.js
@@ -18,14 +18,20 @@ const createTestdir = (...files) => t.testdir({
   },
 })
 
-t.test('package json directory glob', async (t) => {
+t.test('package json directory entry expands to its full contents', async (t) => {
+  // these patterns each resolve to the entire `folder/` subtree:
+  //   - `folder` and `folder/` are literal directory paths
+  //   - `./folder/` is the same after leading-./ normalization
+  //   - `folder/**` and `folder/**/*` are explicit globstars
+  // note that `folder/*` is intentionally not in this list any more --
+  // under real glob semantics it now matches only direct children, see the
+  // following subtest for that behavior.
   const pkgFiles = [
     'folder',
     'folder/',
-    'folder/*',
+    './folder/',
     'folder/**',
     'folder/**/*',
-    './folder/*',
   ]
 
   for (const files of pkgFiles) {
@@ -41,4 +47,126 @@ t.test('package json directory glob', async (t) => {
       ])
     })
   }
+})
+
+t.test('folder/* matches direct children, expanding subdirectory matches', async t => {
+  // Under real glob semantics `folder/*` matches every direct child of
+  // `folder/`. Each matched subdirectory is then expanded to include its
+  // contents (the documented `files[]` directory-expansion behavior), so the
+  // resulting file list is the same as if the user had written `folder/**`.
+  // This convergence makes the loss of the historic `foo/* -> foo/**` rewrite
+  // invisible in practice: identical output for any tree where every leaf
+  // file is reachable through a depth-1 entry, which is always true on a
+  // normal filesystem.
+  const pkg = createTestdir('folder/*')
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const res = await packlist(tree)
+  t.same(res, [
+    'folder/one/file',
+    'folder/two/file',
+    'package.json',
+  ])
+})
+
+t.test('folder/* with mixed depth-1 entries (file + subdir)', async t => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      files: ['dist/*'],
+    }),
+    dist: {
+      'top.js': 'top',
+      sub: {
+        'deep.js': 'deep',
+      },
+    },
+  })
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const res = await packlist(tree)
+  // dist/top.js is a depth-1 file match;
+  // dist/sub/ is a depth-1 directory match, expanded to its contents.
+  t.same(res.sort(), [
+    'dist/sub/deep.js',
+    'dist/top.js',
+    'package.json',
+  ].sort())
+})
+
+t.test('dist-* (cli#7514) includes contents of matched directories', async t => {
+  // regression for https://github.com/npm/cli/issues/7514: in npm-packlist v10,
+  // `files: ["dist-*"]` matched the directory entries dist-cjs/ and dist-es/ but
+  // failed to include their contents, leaving only `dist-other.js` packed.
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'cli-7514',
+      version: '1.0.0',
+      files: ['dist-*'],
+    }),
+    'dist-cjs': { 'index.js': 'cjs' },
+    'dist-es': { 'index.js': 'es' },
+    'dist-other.js': 'other',
+  })
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const res = await packlist(tree)
+  t.same(res.sort(), [
+    'dist-cjs/index.js',
+    'dist-es/index.js',
+    'dist-other.js',
+    'package.json',
+  ].sort())
+})
+
+t.test('lib/ + !lib/test/ (npm-packlist#152) excludes a nested directory', async t => {
+  // documented workaround for the buggy `lib/(!test)` form. with real glob
+  // semantics this is the canonical way to publish lib/ minus its test dir.
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'pl-152',
+      version: '1.0.0',
+      files: ['lib/', '!lib/test/'],
+    }),
+    lib: {
+      'main.js': 'main',
+      'foo.js': 'foo',
+      utils: { 'foo-util.js': 'util' },
+      test: {
+        'main_test.js': 'mt',
+        'foo_test.js': 'ft',
+        utils: { 'foo-util_test.js': 'ut' },
+      },
+    },
+  })
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const res = await packlist(tree)
+  t.same(res.sort(), [
+    'lib/foo.js',
+    'lib/main.js',
+    'lib/utils/foo-util.js',
+    'package.json',
+  ].sort())
+})
+
+t.test('an entry that normalizes to empty (e.g. "./" or "/") is dropped', async t => {
+  // before npm-packlist v11 this would lstat the package root and include
+  // everything; under real glob semantics there is no such entry to glob, so
+  // the user just gets the strict-default required files (package.json).
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'empty-entry',
+      version: '1.0.0',
+      files: ['./', '/', 'a.js'],
+    }),
+    'a.js': '',
+    'b.js': '',
+  })
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const res = await packlist(tree)
+  t.same(res.sort(), [
+    'a.js',
+    'package.json',
+  ].sort())
 })

--- a/test/package-json-files-including-npmignore.js
+++ b/test/package-json-files-including-npmignore.js
@@ -1,3 +1,9 @@
+// In v11+, with pure glob semantics for `files[]`, listing `.npmignore` (or
+// any other always-ignored file from the default ignore list) in `files[]`
+// no longer forces it to be packed. The default-ignore rule wins, because
+// `files[]` only un-ignores against the package.json deny-all and does not
+// override the strict default ignores. Authors who legitimately want to
+// publish a `.npmignore` file should rename it to something else.
 'use strict'
 
 const Arborist = require('@npmcli/arborist')
@@ -27,8 +33,10 @@ t.test('package with negated files', async (t) => {
   const arborist = new Arborist({ path: pkg })
   const tree = await arborist.loadActual()
   const files = await packlist(tree)
+  // lib/.npmignore is dropped (default-ignore wins); lib/sub/two.js is
+  // dropped (lib/.npmignore excludes it). lib/.npmignore being unpacked
+  // does not affect the application of its rules within the walk.
   t.same(files, [
-    'lib/.npmignore',
     'lib/sub/for.js',
     'lib/sub/one.js',
     'lib/sub/tre.js',

--- a/test/package-json-files-wildcard-strict-defaults.js
+++ b/test/package-json-files-wildcard-strict-defaults.js
@@ -1,0 +1,42 @@
+// A wildcard `files` entry like `["**/*"]` expands (with `dot: true`) to include normally-default-ignored paths such as `.git/HEAD`, `.npmrc`, and `node_modules/...`.
+// The strict default ignores must still win — none of those paths should be packed.
+// This locks in the BREAKING CHANGE that listing a default-ignored file in `files[]` no longer forces it to be packed.
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('../')
+
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    files: ['**/*'],
+  }),
+  '.git': {
+    HEAD: 'ref: refs/heads/main\n',
+    config: '[core]\n',
+  },
+  '.npmrc': 'always-auth=true\n',
+  node_modules: {
+    foo: {
+      'package.json': JSON.stringify({ name: 'foo', version: '1.0.0' }),
+      'index.js': 'module.exports = "foo"\n',
+    },
+  },
+  src: {
+    'index.js': 'module.exports = "src"\n',
+    '.hidden.js': 'module.exports = "hidden"\n',
+  },
+  'README.md': '# wildcard files test\n',
+})
+
+t.test('wildcard files[] does not override strict default ignores', async (t) => {
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  t.same(files, [
+    'src/.hidden.js',
+    'src/index.js',
+    'package.json',
+    'README.md',
+  ], 'strict defaults (.git, .npmrc, node_modules) win over wildcard files[]')
+})

--- a/test/package-json-files-with-slashes.js
+++ b/test/package-json-files-with-slashes.js
@@ -1,7 +1,9 @@
-// In v1, this would exclude the 'lib/two.js' file, because
-// the .npmignore is deeper in the tree and thus had higher
-// precedence.  In v2, because /lib/two.js is in the files
-// list as a file path, it will be included no matter what.
+// In v11+, with pure glob semantics for `files[]`, an explicit file path no
+// longer overrides a nested .npmignore. The .npmignore wins, because the
+// `files[]` array is a pure inclusion filter and ignore-walk applies its
+// usual gitignore-style precedence within subdirectories. Authors who need
+// a file to ship despite a nested .npmignore must remove the .npmignore
+// rule (this matches how `node-glob`-style consumers reason about it).
 'use strict'
 
 const Arborist = require('@npmcli/arborist')
@@ -34,12 +36,13 @@ t.test('package with slash files', async (t) => {
   const arborist = new Arborist({ path: pkg })
   const tree = await arborist.loadActual()
   const files = await packlist(tree)
+  // lib/two.js is dropped because lib/.npmignore excludes it; under v11
+  // pure-glob semantics, files[] does not override nested .npmignore rules.
   t.same(files, [
     'fiv.js',
     'lib/for.js',
     'lib/one.js',
     'lib/tre.js',
-    'lib/two.js',
     'package.json',
   ])
 })

--- a/test/package-json-negate-non-root.js
+++ b/test/package-json-negate-non-root.js
@@ -1,5 +1,7 @@
-// exclude readme, license, and licence files if package.json
-// files array includes !readme, !license, or !licence
+// exclude readme, license, and licence files at any depth via globstar
+// negations. this is a behavior change in npm-packlist v11: with real glob
+// semantics, an unanchored pattern only matches the package root, so users
+// who want to exclude nested files must use globstar (**/...) patterns.
 'use strict'
 
 const Arborist = require('@npmcli/arborist')
@@ -10,10 +12,10 @@ const pkg = t.testdir({
   'package.json': JSON.stringify({
     files: [
       'lib',
-      '!readme.md',
-      '!licence',
-      '!license',
-      '!copying',
+      '!**/readme.md',
+      '!**/licence',
+      '!**/license',
+      '!**/copying',
     ],
 
   }),


### PR DESCRIPTION
BREAKING CHANGE: Entries in `files[]` are now interpreted as glob patterns anchored to the package root, with no special-case overrides. Slashless negations like `!readme.md` only match at the root — use `!**/readme.md` to remove at every depth. An exact file path in `files[]` no longer overrides a nested `.npmignore` rule that excludes it; remove the rule from `.npmignore` if you need such a file to ship. Listing a default-ignored file (e.g. `.npmignore`, `.npmrc`) in `files[]` no longer forces it to be packed.

related: https://github.com/npm/statusboard/issues/1082
