### PR TITLE
feat: support a user level ignore file via globalIgnoreFile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const { log } = require('proc-log')
 
 // symbols used to represent synthetic rule sets
 const defaultRules = Symbol('npm-packlist.rules.default')
+const globalRules = Symbol('npm-packlist.rules.global')
 const strictRules = Symbol('npm-packlist.rules.strict')
 
 // There may be others, but :?|<> are handled by node-tar
@@ -84,13 +85,23 @@ class PackWalker extends IgnoreWalker {
       follow: false,
       // we path.resolve() here because ignore-walk doesn't do it and we want full paths
       path: resolve(opts?.path || tree.path).replace(/\\/g, '/'),
-      ignoreFiles: opts?.ignoreFiles || [
+      // globalRules belongs on the root walker only. Child walkers reach it through
+      // parent.filterEntry, where package.json rules can still override it; reapplying
+      // globalRules at the child level would defeat that override.
+      ignoreFiles: opts?.ignoreFiles || (opts?.parent ? [
         defaultRules,
         'package.json',
         '.npmignore',
         '.gitignore',
         strictRules,
-      ],
+      ] : [
+        defaultRules,
+        globalRules,
+        'package.json',
+        '.npmignore',
+        '.gitignore',
+        strictRules,
+      ]),
     }
 
     super(options)
@@ -98,6 +109,8 @@ class PackWalker extends IgnoreWalker {
     this.isPackage = options.isPackage
     this.seen = options.seen || new Set()
     this.tree = tree
+    this.globalIgnoreFile = options.globalIgnoreFile || null
+    this.globalIgnoreRules = options.globalIgnoreRules || null
 
     const additionalDefaults = []
     if (options.prefix && options.workspaces) {
@@ -123,6 +136,31 @@ class PackWalker extends IgnoreWalker {
 
     // go ahead and inject the default rules now
     this.injectRules(defaultRules, [...defaults, ...additionalDefaults])
+
+    // inject the global rules from the user's ignore file. positioned between
+    // defaultRules and package.json so an explicit entry in the package "files"
+    // field can still override. only the root walker carries globalRules in its
+    // ignoreFiles list; child walkers see global exclusions via parent.filterEntry,
+    // which is what lets the package.json `!/path/**` override win.
+    if (this.globalIgnoreRules === null && this.globalIgnoreFile) {
+      try {
+        this.globalIgnoreRules = readFile(this.globalIgnoreFile, { encoding: 'utf8' })
+      } catch (err) {
+        // istanbul ignore next -- only ENOENT is expected here
+        if (err.code !== 'ENOENT') {
+          throw err
+        }
+        this.globalIgnoreRules = ''
+      }
+    }
+    if (this.globalIgnoreRules) {
+      this.injectRules(globalRules, [this.globalIgnoreRules])
+      // istanbul ignore else -- globalIgnoreRules without a filename only happens when
+      // a caller pre-populates rules directly instead of going through globalIgnoreFile
+      if (this.globalIgnoreFile) {
+        log.silly('global-ignore-file', `applied rules from ${this.globalIgnoreFile}`)
+      }
+    }
 
     if (!this.isPackage) {
       // if this instance is not a package, then place some strict default rules

--- a/test/global-ignore-file.js
+++ b/test/global-ignore-file.js
@@ -1,0 +1,177 @@
+'use strict'
+
+const t = require('tap')
+const { join } = require('node:path')
+const packlist = require('../lib/index.js')
+
+// minimal arborist-tree shape that PackWalker consumes.
+const fakeTree = (dir, pkg) => ({
+  path: dir,
+  package: pkg,
+  isProjectRoot: true,
+  edgesOut: new Map(),
+  inventory: new Map(),
+  workspaces: null,
+})
+
+t.test('globalIgnoreFile rules apply on top of defaults', async t => {
+  const root = t.testdir({
+    'global-ignore': '*.iml\n.idea/\n',
+    pkg: {
+      'package.json': JSON.stringify({ name: 'a', version: '1.0.0' }),
+      'index.js': '"use strict"',
+      'foo.iml': 'ide metadata',
+      '.idea': { 'workspace.xml': '<x/>' },
+    },
+  })
+  const dir = join(root, 'pkg')
+
+  const files = await packlist(fakeTree(dir, { name: 'a', version: '1.0.0' }), {
+    path: dir,
+    globalIgnoreFile: join(root, 'global-ignore'),
+  })
+
+  t.same(files.sort(), ['index.js', 'package.json'].sort(), 'globally-ignored files are excluded')
+})
+
+t.test('globalIgnoreFile rules apply when package has local .npmignore', async t => {
+  const root = t.testdir({
+    'global-ignore': '*.iml\n',
+    pkg: {
+      'package.json': JSON.stringify({ name: 'b', version: '1.0.0' }),
+      'index.js': '"use strict"',
+      'scratch.tmp': 'local-only',
+      'foo.iml': 'ide metadata',
+      '.npmignore': '*.tmp\n',
+    },
+  })
+  const dir = join(root, 'pkg')
+
+  const files = await packlist(fakeTree(dir, { name: 'b', version: '1.0.0' }), {
+    path: dir,
+    globalIgnoreFile: join(root, 'global-ignore'),
+  })
+
+  t.notOk(files.includes('foo.iml'), 'global rule still applies')
+  t.notOk(files.includes('scratch.tmp'), 'local .npmignore still applies')
+  t.ok(files.includes('index.js'), 'unrelated files kept')
+})
+
+t.test('files-field directory entry overrides global rule', async t => {
+  // Documented carve-out: a `files` directory includes everything under it, even
+  // entries a global rule would otherwise exclude. The `!/lib/**` rule produced by
+  // processPackage runs on the root walker after globalRules, and child walkers do
+  // not reapply globalRules, so the include wins both at the root and inside lib/.
+  const root = t.testdir({
+    'global-ignore': '*.iml\n',
+    pkg: {
+      'package.json': JSON.stringify({ name: 'c', version: '1.0.0', files: ['lib'] }),
+      lib: {
+        'index.js': '"use strict"',
+        'inside.iml': 'tracked despite global ignore',
+        nested: {
+          'deep.iml': 'also tracked',
+        },
+      },
+    },
+  })
+  const dir = join(root, 'pkg')
+
+  const files = await packlist(fakeTree(dir, { name: 'c', version: '1.0.0', files: ['lib'] }), {
+    path: dir,
+    globalIgnoreFile: join(root, 'global-ignore'),
+  })
+
+  t.ok(files.includes('lib/index.js'), 'files-field directory contents included')
+  t.ok(files.includes('lib/inside.iml'), 'globally-ignored file in a files-field directory survives')
+  t.ok(files.includes('lib/nested/deep.iml'), 'globally-ignored file in a nested subdir of a files-field directory survives')
+})
+
+t.test('missing globalIgnoreFile is silently ignored', async t => {
+  const root = t.testdir({
+    pkg: {
+      'package.json': JSON.stringify({ name: 'd', version: '1.0.0' }),
+      'index.js': '"use strict"',
+    },
+  })
+  const dir = join(root, 'pkg')
+
+  const files = await packlist(fakeTree(dir, { name: 'd', version: '1.0.0' }), {
+    path: dir,
+    globalIgnoreFile: join(root, 'does-not-exist'),
+  })
+
+  t.ok(files.includes('index.js'), 'pack still succeeds when global file is absent')
+})
+
+t.test('rules apply across the walker tree', async t => {
+  const root = t.testdir({
+    'global-ignore': '*.iml\n',
+    pkg: {
+      'package.json': JSON.stringify({ name: 'e', version: '1.0.0' }),
+      'index.js': '"use strict"',
+      sub: { 'foo.iml': 'ignored', 'keep.js': '"use strict"' },
+    },
+  })
+  const dir = join(root, 'pkg')
+
+  const files = await packlist(fakeTree(dir, { name: 'e', version: '1.0.0' }), {
+    path: dir,
+    globalIgnoreFile: join(root, 'global-ignore'),
+  })
+
+  t.ok(files.includes('sub/keep.js'), 'kept subdir file present')
+  t.notOk(files.includes('sub/foo.iml'), 'global rule applied to subdirectories')
+})
+
+t.test('bundled dependencies are not subject to global rules', async t => {
+  // Bundled deps are third-party code we ship as-is.
+  // Applying user-level ignores would surprise the consumer.
+  const root = t.testdir({
+    'global-ignore': '*.iml\n',
+    pkg: {
+      'package.json': JSON.stringify({
+        name: 'f',
+        version: '1.0.0',
+        bundleDependencies: ['dep'],
+        dependencies: { dep: '1.0.0' },
+      }),
+      'index.js': '"use strict"',
+      node_modules: {
+        dep: {
+          'package.json': JSON.stringify({ name: 'dep', version: '1.0.0' }),
+          'foo.iml': 'bundled file that should ship',
+        },
+      },
+    },
+  })
+  const dir = join(root, 'pkg')
+
+  // Build a tree that bundles `dep`.
+  // Real arborist trees are heavy; we assemble the minimum PackWalker reads.
+  const depPath = join(dir, 'node_modules', 'dep')
+  const depNode = {
+    path: depPath,
+    package: { name: 'dep', version: '1.0.0' },
+    isLink: false,
+    target: null,
+    edgesOut: new Map(),
+  }
+  depNode.target = depNode
+  const tree = {
+    path: dir,
+    package: { name: 'f', version: '1.0.0', bundleDependencies: ['dep'] },
+    isProjectRoot: true,
+    edgesOut: new Map([['dep', { to: depNode, peer: false, dev: false }]]),
+    workspaces: null,
+  }
+
+  const files = await packlist(tree, {
+    path: dir,
+    globalIgnoreFile: join(root, 'global-ignore'),
+  })
+  t.ok(
+    files.some(f => f.endsWith('node_modules/dep/foo.iml')),
+    'bundled dep keeps file the global rule would have excluded'
+  )
+})


### PR DESCRIPTION
Adds a `globalIgnoreFile` option pointing to a single ignore file owned by the user and applied to every directory pack. Its parsed contents are injected as a new `globalRules` synthetic rule set, placed between `defaultRules` and `package.json` in the precedence chain. A package's local `.npmignore`, and any specific path listed in its `files` array (which feeds `strictRules`), continue to take precedence over the global rules. The file is read once on the root walker and cached on `globalIgnoreRules` so child walkers reuse the parsed content without reopening the file. Bundled dependencies never receive the option, since they ship third party code as is.

Includes unit tests for default layering, coexistence with a local `.npmignore`, the package "files" carve out, missing file no op, subdirectory propagation, and bundled dependency isolation.

Required for https://github.com/npm/cli/pull/9351