### PR TITLE
fix!: use real glob semantics for package.json files array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -302,6 +302,21 @@ class PackWalker extends IgnoreWalker {
           continue
         }
 
+        // handle simple extglob-style negation patterns like `lib/(!test)` which
+        // some users relied on historically. Translate to an include of the
+        // directory plus a re-ignore of the excluded child so that `lib/(!test)`
+        // behaves like `lib/**` minus `lib/test/**`.
+        const extglobMatch = (!isNegation) && pattern.match(new RegExp('^(.+?)/\\(!([^/]+)\\)$'))
+        if (extglobMatch) {
+          const base = extglobMatch[1]
+          const excl = extglobMatch[2]
+          ignores.push(`!/${base}`)
+          ignores.push(`!/${base}/**`)
+          ignores.push(`${base}/${excl}`)
+          ignores.push(`${base}/${excl}/**`)
+          continue
+        }
+
         // expand the entry as a glob against the package root.
         // literal paths (e.g. `lib`, `lib/foo.js`) are valid globs and resolve to themselves;
         // patterns (e.g. `dist-*`, `**/*.js`) resolve to all matching entries;
@@ -331,6 +346,18 @@ class PackWalker extends IgnoreWalker {
           // istanbul ignore else -- non-file-non-dir matches (sockets, fifos, broken symlinks) drop silently.
           if (match.isFile()) {
             ignores.push(`${prefix}/${rel}`)
+          }
+        }
+        // If the user specified a positive pattern that could match directories but
+        // the glob expansion didn't explicitly return directory entries (due to
+        // differences in glob implementations), also add a recursive include for
+        // that pattern so that directory contents are included (matches npm v8
+        // behavior where `dist-*` would include `dist-cjs/index.js`).
+        if (!isNegation) {
+          // only add the recursive expansion when the original pattern isn't
+          // already an explicit directory or recursive pattern
+          if (!pattern.endsWith('/**') && !pattern.endsWith('/') && !pattern.includes('/')) {
+            ignores.push(`${prefix}/${pattern}/**`)
           }
         }
       }

--- a/test/package-json-files-dist-star.js
+++ b/test/package-json-files-dist-star.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('..')
+
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    files: [
+      'dist-*',
+    ],
+  }),
+  'dist-cjs': {
+    'index.js': 'cjs',
+  },
+  'dist-es': {
+    'index.js': 'es',
+  },
+  'dist-other.js': 'other',
+})
+
+t.test('package with dist-* files pattern', async (t) => {
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+
+  t.match(files, [
+    'dist-other.js',
+    'dist-cjs/index.js',
+    'dist-es/index.js',
+    'package.json',
+  ])
+})

--- a/test/package-json-files-extglob-negation.js
+++ b/test/package-json-files-extglob-negation.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('..')
+
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    files: [
+      'lib/(!test)',
+    ],
+  }),
+  lib: {
+    'main.js': 'main',
+    'foo.js': 'foo',
+    utils: {
+      'foo-util.js': 'util',
+    },
+    test: {
+      'main_test.js': 't',
+    },
+  },
+})
+
+t.test('package with lib/(!test) files pattern', async (t) => {
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+
+  const expected = [
+    'lib/main.js',
+    'lib/foo.js',
+    'lib/utils/foo-util.js',
+    'package.json',
+  ]
+  for (const e of expected) {
+    t.ok(files.includes(e), `includes ${e}`)
+  }
+})


### PR DESCRIPTION
<!-- What / Why -->

Restore npm-packlist [files[]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) matching behavior for directory-like glob patterns and simple extglob negation patterns.

This change fixes [files: ["dist-*"]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so matching directory trees such as dist-cjs/index.js and dist-es/index.js are included, matching the historical npm packaging expectation. It also adds support for patterns like [lib/(!test)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) by treating them as an include of [lib/**](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) minus [lib/test/**](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), preventing the reported undermatch behavior.

References
Fixes [#7514](https://github.com/npm/cli/issues/7514)
Fixes [#152](https://github.com/npm/npm-packlist/issues/152)
Related to [npm/statusboard#1068](https://github.com/npm/statusboard/issues/1082)