### PR TITLE
feat: exclude patchedDependencies patch files from the package tarball

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -305,6 +305,7 @@ class PackWalker extends IgnoreWalker {
       browser,
       files,
       main,
+      patchedDependencies,
     } = this.tree.package
 
     // rules in these arrays are inverted since they are patterns we want to _not_ ignore
@@ -391,6 +392,32 @@ class PackWalker extends IgnoreWalker {
     if (bin) {
       for (const key in bin) {
         strict.push(`!/${bin[key]}`)
+      }
+    }
+
+    // patch files declared in patchedDependencies are project-local fixes and must never ship.
+    // patchedDependencies is root-only state, so this applies only to the package being packed.
+    // each declared patch file is force-excluded even when it was added via "files".
+    // only the exact files are excluded, never their directory, so a shared dir keeps its other contents.
+    if (this.tree.isProjectRoot && patchedDependencies && typeof patchedDependencies === 'object') {
+      for (const patchPath of Object.values(patchedDependencies)) {
+        if (typeof patchPath !== 'string') {
+          continue
+        }
+        const rel = normalizePath(patchPath).replace(/^\.?\//, '').replace(/\/+$/, '')
+        // skip absolute paths or paths that escape the package root, which are never packed anyway
+        if (!rel || rel.startsWith('/') || rel === '..' || rel.startsWith('../') || rel.includes('/../')) {
+          continue
+        }
+        // warn when a "files" entry pulled the patch file in, either directly or via its directory
+        const parentGlob = `!/${normalizePath(dirname(rel))}/**`
+        if (files && (ignores.includes(`!/${rel}`) || ignores.includes(parentGlob))) {
+          log.warn(
+            'patched-dependencies',
+            `excluding "${rel}" from the package tarball: patch files in patchedDependencies must not be published`
+          )
+        }
+        strict.push(`/${rel}`)
       }
     }
 

--- a/test/patched-dependencies.js
+++ b/test/patched-dependencies.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('../')
+
+t.test('a dedicated patch dir is dropped even when listed in "files"', async (t) => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'p',
+      version: '1.0.0',
+      files: ['lib', 'patches'],
+      patchedDependencies: { 'abbrev@2.0.0': 'patches/abbrev@2.0.0.patch' },
+    }),
+    lib: { 'index.js': 'code' },
+    patches: { 'abbrev@2.0.0.patch': 'the patch' },
+  })
+
+  // a "files" entry that names the patch dir should produce a warning
+  const warnings = []
+  const onLog = (level, ...args) => {
+    if (level === 'warn' && args[0] === 'patched-dependencies') {
+      warnings.push(args[1])
+    }
+  }
+  process.on('log', onLog)
+  t.teardown(() => process.removeListener('log', onLog))
+
+  const tree = await new Arborist({ path: pkg }).loadActual()
+  const files = await packlist(tree)
+
+  t.same(files, ['lib/index.js', 'package.json'], 'the now-empty patch dir is excluded')
+  t.match(warnings, [/excluding "patches\/abbrev@2.0.0.patch"/], 'warns that the patch file was dropped')
+})
+
+t.test('a patch file in a shared dir is dropped without dropping the rest of the dir', async (t) => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'p',
+      version: '1.0.0',
+      patchedDependencies: { 'abbrev@2.0.0': 'src/abbrev@2.0.0.patch' },
+    }),
+    src: { 'index.js': 'code', 'abbrev@2.0.0.patch': 'the patch' },
+  })
+  const tree = await new Arborist({ path: pkg }).loadActual()
+  const files = await packlist(tree)
+  t.notOk(files.includes('src/abbrev@2.0.0.patch'), 'the patch file is excluded')
+  t.ok(files.includes('src/index.js'), 'sibling source in the same dir still ships')
+})
+
+t.test('malformed, absolute, and escaping patch paths are skipped safely', async (t) => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'p',
+      version: '1.0.0',
+      patchedDependencies: {
+        // a non-string value is skipped
+        'bad@1.0.0': { not: 'a string' },
+        // an absolute path is never packed, so it is skipped
+        'abs@1.0.0': '/etc/passwd.patch',
+        // a path that escapes the package root is skipped
+        'esc@1.0.0': '../evil.patch',
+        // a valid relative patch file is excluded
+        'abbrev@2.0.0': 'patches/abbrev@2.0.0.patch',
+      },
+    }),
+    'index.js': 'code',
+    patches: { 'abbrev@2.0.0.patch': 'the patch' },
+  })
+  const tree = await new Arborist({ path: pkg }).loadActual()
+  const files = await packlist(tree)
+  t.notOk(files.some((f) => f.startsWith('patches')), 'the valid patch file is excluded')
+  t.ok(files.includes('index.js'), 'unrelated source still ships')
+})
+
+t.test('a bundled dependency with patchedDependencies does not prune its own files', async (t) => {
+  const pkg = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'p',
+      version: '1.0.0',
+      dependencies: { dep: '1.0.0' },
+      bundleDependencies: ['dep'],
+    }),
+    'index.js': 'code',
+    node_modules: {
+      dep: {
+        // patchedDependencies here must be ignored: it is only honored in a root manifest
+        'package.json': JSON.stringify({
+          name: 'dep',
+          version: '1.0.0',
+          patchedDependencies: { 'x@1.0.0': 'patches/x@1.0.0.patch' },
+        }),
+        'index.js': 'dep code',
+        patches: { 'x@1.0.0.patch': 'should still ship from a bundled dep' },
+      },
+    },
+  })
+  const tree = await new Arborist({ path: pkg }).loadActual()
+  const files = await packlist(tree)
+  t.ok(files.includes('node_modules/dep/patches/x@1.0.0.patch'),
+    'the bundled dep\'s patch dir is not pruned')
+})


### PR DESCRIPTION
Part of native dependency patching ([npm/rfcs#862](https://github.com/npm/rfcs/pull/862)). This force-excludes the patch files declared in the root package's `patchedDependencies` from the packed file list, even when they are listed in `files`.

## Why

`patchedDependencies` maps a dependency selector to a project-local patch file (e.g. `"abbrev@2.0.0": "patches/abbrev@2.0.0.patch"`). Those patches are a property of the project, not something a consumer of the published package applies. Without this, publishing a patched project would ship the patch files — and, once pacote strips the `patchedDependencies` field from the tarball's `package.json`, they would be dangling, unreferenced files. Excluding them keeps the published tarball clean.

## How

In `PackWalker.processPackage`, when the walker is the project root and the manifest declares `patchedDependencies`, each declared patch file path is pushed onto the strict (un-overridable) rule set, so it is excluded even if `files` lists it. Design choices:

- **Exact files, not directories.** Only the declared patch files are excluded — never their directory. A dedicated `patches/` dir becomes empty and drops out naturally, but a patch that lives in a shared directory (e.g. `src/foo.patch`) does not take the rest of `src/` down with it.
- **`--patches-dir` honored for free.** The location is read straight off the `patchedDependencies` values, which already encode wherever the patches were written.
- **Root-only.** `patchedDependencies` is root-only state, so the block is gated to the project root and never prunes a bundled dependency's files.
- **Path safety.** Absolute paths and paths that escape the package root are skipped (they are never packed anyway).
- **Warns** when a `files` entry pulled a patch file in (directly or via its directory), so the override is not silent.

## References

Part of
- https://github.com/npm/rfcs/pull/862

Related to
- https://github.com/npm/cli/pull/9439
- https://github.com/npm/pacote/pull/497
