### PR TITLE
feat: exclude root `.npm-extension.mjs`/`.cjs` from package tarballs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -326,6 +326,8 @@ class PackWalker extends IgnoreWalker {
       '/pnpm-lock.yaml',
       '/bun.lockb',
       '/bun.lock',
+      '/.npm-extension.mjs',
+      '/.npm-extension.cjs',
     ]
 
     // if we have a files array in our package, we need to pull rules from it

--- a/test/cannot-include-npm-extension.js
+++ b/test/cannot-include-npm-extension.js
@@ -1,0 +1,25 @@
+// root .npm-extension.{mjs,cjs} are npm install policy, never package contents
+'use strict'
+
+const Arborist = require('@npmcli/arborist')
+const t = require('tap')
+const packlist = require('../')
+
+const pkg = t.testdir({
+  'package.json': JSON.stringify({
+    files: ['lib', '.npm-extension.mjs', '.npm-extension.cjs'],
+  }),
+  '.npm-extension.mjs': 'export function transformManifest (p) { return p }\n',
+  '.npm-extension.cjs': 'module.exports = { transformManifest (p) { return p } }\n',
+  lib: { 'index.js': '' },
+})
+
+t.test('try to include .npm-extension files but cannot', async (t) => {
+  const arborist = new Arborist({ path: pkg })
+  const tree = await arborist.loadActual()
+  const files = await packlist(tree)
+  t.same(files, [
+    'lib/index.js',
+    'package.json',
+  ], 'both .npm-extension files are excluded even when listed in files')
+})


### PR DESCRIPTION
Force-excludes root `.npm-extension.mjs` and `.npm-extension.cjs` from the package tarball, even when a package's `files` array would otherwise include them.

These files are root-owned npm install policy (the imperative `transformManifest` extension point from [npm/rfcs#903](https://github.com/npm/rfcs/pull/903)), not package contents — the same category as `.npmrc`, VCS metadata, lockfiles, and native-patch files, which npm-packlist already strips unconditionally. Keeping them out of the tarball lets a public package use `.npm-extension` locally (for its own install, tests, and linked-install migration) without publishing that policy to consumers or bloating its packument.

## What

- Add `/.npm-extension.mjs` and `/.npm-extension.cjs` to the strict (forced) exclusion list, alongside the existing lockfile/`.npmrc`/VCS entries.
- Root-anchored: only the package's own root file is excluded; nested paths are unaffected (a dependency's `.npm-extension` is never npm's concern at pack time).

## Test

- `test/cannot-include-npm-extension.js`: a package whose `files` array lists both `.npm-extension.mjs` and `.npm-extension.cjs` still excludes them from the packed file list.

## References

Supports https://github.com/npm/rfcs/pull/903
Consumed by the npm CLI `.npm-extension` implementation https://github.com/npm/cli/pull/9586 (pacote will pick this up via a dependency bump once released).
